### PR TITLE
Fix deltakit-stim + stim compatability issue

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,21 +24,6 @@ jobs:
         uses: astral-sh/setup-uv@v7
       - name: Package synchronisation
         run: uv sync --python 3.13 --resolution highest --group test
-      - name: Set up Bazel
-        uses: bazel-contrib/setup-bazel@0.18.0
-        with:
-          # Avoid downloading Bazel every time.
-          bazelisk-cache: true
-          # Store build cache per workflow.
-          disk-cache: ${{ github.workflow }}
-          # Share repository cache between workflows.
-          repository-cache: true
-      - name: Clean Bazel build artifacts
-        run: bazel clean
-      - name: Build wheel
-        run: bazel build //:stim_dev_wheel
-      - name: Install wheel
-        run: uv pip install bazel-bin/stim-0.0.dev0-py3-none-any.whl
       - name: Test bindings
         run: uv run --python 3.13 --no-sync pytest
       # - name: Run failing binding tests

--- a/doc/result_formats.md
+++ b/doc/result_formats.md
@@ -43,11 +43,11 @@ This is the default format used by Stim, because it's the easiest to understand.
 *Example of producing 01 format data using stim's python API:*
 
     >>> import pathlib
-    >>> import stim
+    >>> import lestim
     >>> import tempfile
     >>> with tempfile.TemporaryDirectory() as d:
     ...     path = str(pathlib.Path(d) / "tmp.dat")
-    ...     stim.Circuit("""
+    ...     lestim.Circuit("""
     ...         X 1
     ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
     ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="01")
@@ -107,11 +107,11 @@ This format requires the reader to know the number of bits in each shot.
 *Example of producing b8 format data using stim's python API:*
 
     >>> import pathlib
-    >>> import stim
+    >>> import lestim
     >>> import tempfile
     >>> with tempfile.TemporaryDirectory() as d:
     ...     path = str(pathlib.Path(d) / "tmp.dat")
-    ...     stim.Circuit("""
+    ...     lestim.Circuit("""
     ...         X 1
     ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
     ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="b8")
@@ -169,11 +169,11 @@ wants to produce vectors of bits instead of sets.
 *Example of producing dets format data using stim's python API:*
 
     >>> import pathlib
-    >>> import stim
+    >>> import lestim
     >>> import tempfile
     >>> with tempfile.TemporaryDirectory() as d:
     ...     path = str(pathlib.Path(d) / "tmp.dat")
-    ...     stim.Circuit("""
+    ...     lestim.Circuit("""
     ...         X 1
     ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1 0 1
     ...     """).compile_sampler().sample_write(shots=3, filepath=path, format="dets")
@@ -185,7 +185,7 @@ wants to produce vectors of bits instead of sets.
 
     >>> with tempfile.TemporaryDirectory() as d:
     ...     path = str(pathlib.Path(d) / "tmp.dat")
-    ...     stim.Circuit("""
+    ...     lestim.Circuit("""
     ...         X_ERROR(1) 1
     ...         M 0 1 2
     ...         DETECTOR rec[-1]
@@ -266,11 +266,11 @@ events.
 *Example of producing hits format data using stim's python API:*
 
     >>> import pathlib
-    >>> import stim
+    >>> import lestim
     >>> import tempfile
     >>> with tempfile.TemporaryDirectory() as d:
     ...     path = str(pathlib.Path(d) / "tmp.dat")
-    ...     stim.Circuit("""
+    ...     lestim.Circuit("""
     ...         X 1
     ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
     ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="hits")
@@ -335,11 +335,11 @@ where it is possible to parallelize across shots using SIMD instructions.
 *Example of producing ptb64 format data using stim's python API:*
 
     >>> import pathlib
-    >>> import stim
+    >>> import lestim
     >>> import tempfile
     >>> with tempfile.TemporaryDirectory() as d:
     ...     path = str(pathlib.Path(d) / "tmp.dat")
-    ...     stim.Circuit("""
+    ...     lestim.Circuit("""
     ...         X 1
     ...         M 0 1
     ...     """).compile_sampler().sample_write(shots=64, filepath=path, format="ptb64")
@@ -405,11 +405,11 @@ events.
 *Example of producing r8 format data using stim's python API:*
 
     >>> import pathlib
-    >>> import stim
+    >>> import lestim
     >>> import tempfile
     >>> with tempfile.TemporaryDirectory() as d:
     ...     path = str(pathlib.Path(d) / "tmp.dat")
-    ...     stim.Circuit("""
+    ...     lestim.Circuit("""
     ...         X 1
     ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
     ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="r8")
@@ -419,7 +419,7 @@ events.
 
     >>> with tempfile.TemporaryDirectory() as d:
     ...     path = str(pathlib.Path(d) / "tmp.dat")
-    ...     stim.Circuit("""
+    ...     lestim.Circuit("""
     ...         X 1
     ...         M 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
     ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="r8")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ test = [
   "pytest>=9.0",
   "pytest-cov>=7.0",
   "pytest-skip-slow>=0.0.5",
+  "stim>=1.13",
   { include-group = "tests_extras" },
 ]
 lint = ["mypy~=1.17", "ruff~=0.14", "typos~=1.34", "deptry~=0.23", "pydoclint~=0.8"]

--- a/src/stim/circuit/circuit_instruction_pybind_test.py
+++ b/src/stim/circuit/circuit_instruction_pybind_test.py
@@ -12,85 +12,85 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import stim
+import lestim
 import pytest
 
 
 def test_init_and_equality():
-    i = stim.CircuitInstruction("X_ERROR", [stim.GateTarget(5)], [0.5])
+    i = lestim.CircuitInstruction("X_ERROR", [lestim.GateTarget(5)], [0.5])
     assert i.name == "X_ERROR"
-    assert i.targets_copy() == [stim.GateTarget(5)]
+    assert i.targets_copy() == [lestim.GateTarget(5)]
     assert i.gate_args_copy() == [0.5]
-    i2 = stim.CircuitInstruction(name="X_ERROR", targets=[stim.GateTarget(5)], gate_args=[0.5])
+    i2 = lestim.CircuitInstruction(name="X_ERROR", targets=[lestim.GateTarget(5)], gate_args=[0.5])
     assert i == i2
 
-    assert i == stim.CircuitInstruction("X_ERROR", [stim.GateTarget(5)], [0.5])
-    assert not (i == stim.CircuitInstruction("Z_ERROR", [stim.GateTarget(5)], [0.5]))
-    assert i != stim.CircuitInstruction("Z_ERROR", [stim.GateTarget(5)], [0.5])
-    assert i != stim.CircuitInstruction("X_ERROR", [stim.GateTarget(5), stim.GateTarget(6)], [0.5])
-    assert i != stim.CircuitInstruction("X_ERROR", [stim.GateTarget(5)], [0.25])
+    assert i == lestim.CircuitInstruction("X_ERROR", [lestim.GateTarget(5)], [0.5])
+    assert not (i == lestim.CircuitInstruction("Z_ERROR", [lestim.GateTarget(5)], [0.5]))
+    assert i != lestim.CircuitInstruction("Z_ERROR", [lestim.GateTarget(5)], [0.5])
+    assert i != lestim.CircuitInstruction("X_ERROR", [lestim.GateTarget(5), lestim.GateTarget(6)], [0.5])
+    assert i != lestim.CircuitInstruction("X_ERROR", [lestim.GateTarget(5)], [0.25])
 
 
 @pytest.mark.parametrize("value", [
-    stim.CircuitInstruction("X_ERROR", [stim.GateTarget(5)], [0.5]),
-    stim.CircuitInstruction("M", [stim.GateTarget(stim.target_inv(3))]),
+    lestim.CircuitInstruction("X_ERROR", [lestim.GateTarget(5)], [0.5]),
+    lestim.CircuitInstruction("M", [lestim.GateTarget(lestim.target_inv(3))]),
 ])
 def test_repr(value):
-    assert eval(repr(value), {'stim': stim}) == value
-    assert repr(eval(repr(value), {'stim': stim})) == repr(value)
+    assert eval(repr(value), {'stim': lestim}) == value
+    assert repr(eval(repr(value), {'stim': lestim})) == repr(value)
 
 
 def test_str():
-    assert str(stim.CircuitInstruction("X_ERROR", [stim.GateTarget(5)], [0.5])) == "X_ERROR(0.5) 5"
+    assert str(lestim.CircuitInstruction("X_ERROR", [lestim.GateTarget(5)], [0.5])) == "X_ERROR(0.5) 5"
 
 
 def test_hashable():
-    a = stim.CircuitInstruction("X_ERROR", [stim.GateTarget(5)], [0.5])
-    b = stim.CircuitInstruction("DEPOLARIZE1", [stim.GateTarget(5)], [0.5])
-    c = stim.CircuitInstruction("X_ERROR", [stim.GateTarget(5)], [0.5])
+    a = lestim.CircuitInstruction("X_ERROR", [lestim.GateTarget(5)], [0.5])
+    b = lestim.CircuitInstruction("DEPOLARIZE1", [lestim.GateTarget(5)], [0.5])
+    c = lestim.CircuitInstruction("X_ERROR", [lestim.GateTarget(5)], [0.5])
     assert hash(a) == hash(c)
     assert len({a, b, c}) == 2
 
 
 def test_num_measurements():
-    assert stim.CircuitInstruction("X", [1, 2, 3]).num_measurements == 0
-    assert stim.CircuitInstruction("MXX", [1, 2]).num_measurements == 1
-    assert stim.CircuitInstruction("M", [1, 2]).num_measurements == 2
-    assert stim.CircuitInstruction("MPAD", [0, 1, 0]).num_measurements == 3
+    assert lestim.CircuitInstruction("X", [1, 2, 3]).num_measurements == 0
+    assert lestim.CircuitInstruction("MXX", [1, 2]).num_measurements == 1
+    assert lestim.CircuitInstruction("M", [1, 2]).num_measurements == 2
+    assert lestim.CircuitInstruction("MPAD", [0, 1, 0]).num_measurements == 3
 
 
 def test_target_groups():
-    assert stim.CircuitInstruction("MPAD", [0, 1, 0]).target_groups() == [
-        [stim.GateTarget(0)],
-        [stim.GateTarget(1)],
-        [stim.GateTarget(0)],
+    assert lestim.CircuitInstruction("MPAD", [0, 1, 0]).target_groups() == [
+        [lestim.GateTarget(0)],
+        [lestim.GateTarget(1)],
+        [lestim.GateTarget(0)],
     ]
-    assert stim.CircuitInstruction("H", []).target_groups() == []
-    assert stim.CircuitInstruction("H", [1]).target_groups() == [[stim.GateTarget(1)]]
-    assert stim.CircuitInstruction("H", [2, 3]).target_groups() == [[stim.GateTarget(2)], [stim.GateTarget(3)]]
-    assert stim.CircuitInstruction("CX", []).target_groups() == []
-    assert stim.CircuitInstruction("CX", [0, 1]).target_groups() == [[stim.GateTarget(0), stim.GateTarget(1)]]
-    assert stim.CircuitInstruction("CX", [2, 3, 5, 7]).target_groups() == [[stim.GateTarget(2), stim.GateTarget(3)], [stim.GateTarget(5), stim.GateTarget(7)]]
-    assert stim.CircuitInstruction("DETECTOR", []).target_groups() == []
-    assert stim.CircuitInstruction("CORRELATED_ERROR", [], [0.001]).target_groups() == []
-    assert stim.CircuitInstruction("MPP", []).target_groups() == []
-    assert stim.CircuitInstruction("MPAD", []).target_groups() == []
-    assert stim.CircuitInstruction("QUBIT_COORDS", [1, 2]).target_groups() == [[stim.GateTarget(1)], [stim.GateTarget(2)]]
+    assert lestim.CircuitInstruction("H", []).target_groups() == []
+    assert lestim.CircuitInstruction("H", [1]).target_groups() == [[lestim.GateTarget(1)]]
+    assert lestim.CircuitInstruction("H", [2, 3]).target_groups() == [[lestim.GateTarget(2)], [lestim.GateTarget(3)]]
+    assert lestim.CircuitInstruction("CX", []).target_groups() == []
+    assert lestim.CircuitInstruction("CX", [0, 1]).target_groups() == [[lestim.GateTarget(0), lestim.GateTarget(1)]]
+    assert lestim.CircuitInstruction("CX", [2, 3, 5, 7]).target_groups() == [[lestim.GateTarget(2), lestim.GateTarget(3)], [lestim.GateTarget(5), lestim.GateTarget(7)]]
+    assert lestim.CircuitInstruction("DETECTOR", []).target_groups() == []
+    assert lestim.CircuitInstruction("CORRELATED_ERROR", [], [0.001]).target_groups() == []
+    assert lestim.CircuitInstruction("MPP", []).target_groups() == []
+    assert lestim.CircuitInstruction("MPAD", []).target_groups() == []
+    assert lestim.CircuitInstruction("QUBIT_COORDS", [1, 2]).target_groups() == [[lestim.GateTarget(1)], [lestim.GateTarget(2)]]
 
 
 def test_eager_validate():
     with pytest.raises(ValueError, match="0, 1, 2"):
-        stim.CircuitInstruction("CX", [0, 1, 2])
+        lestim.CircuitInstruction("CX", [0, 1, 2])
 
 
 def test_init_from_str():
-    assert stim.CircuitInstruction("CX", [0, 1]) == stim.CircuitInstruction("CX 0 1")
+    assert lestim.CircuitInstruction("CX", [0, 1]) == lestim.CircuitInstruction("CX 0 1")
 
     with pytest.raises(ValueError, match="single CircuitInstruction"):
-        stim.CircuitInstruction("")
+        lestim.CircuitInstruction("")
 
     with pytest.raises(ValueError, match="single CircuitInstruction"):
-        stim.CircuitInstruction("""
+        lestim.CircuitInstruction("""
             REPEAT 5 {
                 H 0
                 X 1
@@ -98,7 +98,7 @@ def test_init_from_str():
         """)
 
     with pytest.raises(ValueError, match="single CircuitInstruction"):
-        stim.CircuitInstruction("""
+        lestim.CircuitInstruction("""
             H 0 
             X 1
         """)

--- a/src/stim/circuit/circuit_pybind_test.py
+++ b/src/stim/circuit/circuit_pybind_test.py
@@ -16,13 +16,13 @@ import pathlib
 import tempfile
 from typing import cast
 
-import stim
+import lestim
 import pytest
 import numpy as np
 
 
 def test_circuit_init_num_measurements_num_qubits():
-    c = stim.Circuit()
+    c = lestim.Circuit()
     assert c.num_qubits == c.num_measurements == 0
     assert str(c).strip() == ""
 
@@ -43,7 +43,7 @@ M 0
 
 
 def test_circuit_append_operation():
-    c = stim.Circuit()
+    c = lestim.Circuit()
 
     with pytest.raises(IndexError, match="Gate not found"):
         c.append_operation("NOT_A_GATE", [0])
@@ -52,27 +52,27 @@ def test_circuit_append_operation():
     with pytest.raises(ValueError, match="takes 0"):
         c.append_operation("X", [0], 0.5)
     with pytest.raises(ValueError, match="invalid modifiers"):
-        c.append_operation("X", [stim.target_inv(0)])
+        c.append_operation("X", [lestim.target_inv(0)])
     with pytest.raises(ValueError, match="invalid modifiers"):
-        c.append_operation("X", [stim.target_x(0)])
+        c.append_operation("X", [lestim.target_x(0)])
     with pytest.raises(IndexError, match="lookback"):
-        stim.target_rec(0)
+        lestim.target_rec(0)
     with pytest.raises(IndexError, match="lookback"):
-        stim.target_rec(1)
+        lestim.target_rec(1)
     with pytest.raises(IndexError, match="lookback"):
-        stim.target_rec(-2**30)
-    assert stim.target_rec(-1) is not None
-    assert stim.target_rec(-15) is not None
+        lestim.target_rec(-2**30)
+    assert lestim.target_rec(-1) is not None
+    assert lestim.target_rec(-15) is not None
 
     c.append_operation("X", [0])
     c.append_operation("X", [1, 2])
     c.append_operation("X", [3])
     c.append_operation("CNOT", [0, 1])
-    c.append_operation("M", [0, stim.target_inv(1)])
+    c.append_operation("M", [0, lestim.target_inv(1)])
     c.append_operation("X_ERROR", [0], 0.25)
-    c.append_operation("CORRELATED_ERROR", [stim.target_x(0), stim.target_y(1)], 0.5)
-    c.append_operation("DETECTOR", [stim.target_rec(-1)])
-    c.append_operation("OBSERVABLE_INCLUDE", [stim.target_rec(-1), stim.target_rec(-2)], 5)
+    c.append_operation("CORRELATED_ERROR", [lestim.target_x(0), lestim.target_y(1)], 0.5)
+    c.append_operation("DETECTOR", [lestim.target_rec(-1)])
+    c.append_operation("OBSERVABLE_INCLUDE", [lestim.target_rec(-1), lestim.target_rec(-2)], 5)
     assert str(c).strip() == """
 X 0 1 2 3
 CX 0 1
@@ -85,10 +85,10 @@ OBSERVABLE_INCLUDE(5) rec[-1] rec[-2]
 
 
 def test_circuit_iadd():
-    c = stim.Circuit()
+    c = lestim.Circuit()
     alias = c
     c.append_operation("X", [1, 2])
-    c2 = stim.Circuit()
+    c2 = lestim.Circuit()
     c2.append_operation("Y", [3])
     c2.append_operation("M", [4])
     c += c2
@@ -112,9 +112,9 @@ M 4
 
 
 def test_circuit_add():
-    c = stim.Circuit()
+    c = lestim.Circuit()
     c.append_operation("X", [1, 2])
-    c2 = stim.Circuit()
+    c2 = lestim.Circuit()
     c2.append_operation("Y", [3])
     c2.append_operation("M", [4])
     assert str(c + c2).strip() == """
@@ -132,7 +132,7 @@ M 4
 
 
 def test_circuit_mul():
-    c = stim.Circuit()
+    c = lestim.Circuit()
     c.append_operation("Y", [3])
     c.append_operation("M", [4])
     assert str(c * 2) == str(2 * c) == """
@@ -167,7 +167,7 @@ REPEAT 3 {
 
 
 def test_circuit_repr():
-    v = stim.Circuit("""
+    v = lestim.Circuit("""
         X 0
         M 0
     """)
@@ -176,7 +176,7 @@ def test_circuit_repr():
     X 0
     M 0
 ''')"""
-    assert eval(r, {'stim': stim}) == v
+    assert eval(r, {'stim': lestim}) == v
 
 
 def test_circuit_eq():
@@ -188,33 +188,33 @@ def test_circuit_eq():
         Y 0
         M 0
     """
-    assert stim.Circuit() == stim.Circuit()
-    assert stim.Circuit() != stim.Circuit(a)
-    assert not (stim.Circuit() != stim.Circuit())
-    assert not (stim.Circuit() == stim.Circuit(a))
-    assert stim.Circuit(a) == stim.Circuit(a)
-    assert stim.Circuit(b) == stim.Circuit(b)
-    assert stim.Circuit(a) != stim.Circuit(b)
+    assert lestim.Circuit() == lestim.Circuit()
+    assert lestim.Circuit() != lestim.Circuit(a)
+    assert not (lestim.Circuit() != lestim.Circuit())
+    assert not (lestim.Circuit() == lestim.Circuit(a))
+    assert lestim.Circuit(a) == lestim.Circuit(a)
+    assert lestim.Circuit(b) == lestim.Circuit(b)
+    assert lestim.Circuit(a) != lestim.Circuit(b)
 
-    assert stim.Circuit() != None
-    assert stim.Circuit != object()
-    assert stim.Circuit != "another type"
-    assert not (stim.Circuit == None)
-    assert not (stim.Circuit == object())
-    assert not (stim.Circuit == "another type")
+    assert lestim.Circuit() != None
+    assert lestim.Circuit != object()
+    assert lestim.Circuit != "another type"
+    assert not (lestim.Circuit == None)
+    assert not (lestim.Circuit == object())
+    assert not (lestim.Circuit == "another type")
 
 
 def test_circuit_clear():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         X 0
         M 0
     """)
     c.clear()
-    assert c == stim.Circuit()
+    assert c == lestim.Circuit()
 
 
 def test_circuit_compile_sampler():
-    c = stim.Circuit()
+    c = lestim.Circuit()
     s = c.compile_sampler()
     c.append_operation("M", [0])
     assert repr(s) == "stim.CompiledMeasurementSampler(stim.Circuit())"
@@ -235,18 +235,18 @@ stim.CompiledMeasurementSampler(stim.Circuit('''
     H 0 1 2 3 4
     M 0 1 2 3 4
 '''))
-    """.strip() == str(stim.CompiledMeasurementSampler(c))
+    """.strip() == str(lestim.CompiledMeasurementSampler(c))
 
     # Check that expression can be evaluated.
-    _ = eval(r, {"stim": stim})
+    _ = eval(r, {"stim": lestim})
 
 
 def test_circuit_compile_detector_sampler():
-    c = stim.Circuit()
+    c = lestim.Circuit()
     s = c.compile_detector_sampler()
     c.append_operation("M", [0])
     assert repr(s) == "stim.CompiledDetectorSampler(stim.Circuit())"
-    c.append_operation("DETECTOR", [stim.target_rec(-1)])
+    c.append_operation("DETECTOR", [lestim.target_rec(-1)])
     s = c.compile_detector_sampler()
     r = repr(s)
     assert r == """
@@ -257,11 +257,11 @@ stim.CompiledDetectorSampler(stim.Circuit('''
     """.strip()
 
     # Check that expression can be evaluated.
-    _ = eval(r, {"stim": stim})
+    _ = eval(r, {"stim": lestim})
 
 
 def test_circuit_flattened_operations():
-    assert stim.Circuit('''
+    assert lestim.Circuit('''
         H 0
         REPEAT 3 {
             X_ERROR(0.125) 1
@@ -281,21 +281,21 @@ def test_circuit_flattened_operations():
 
 
 def test_copy():
-    c = stim.Circuit("H 0")
+    c = lestim.Circuit("H 0")
     c2 = c.copy()
     assert c == c2
     assert c is not c2
 
 
 def test_hash():
-    # stim.Circuit is mutable. It must not also be value-hashable.
+    # lestim.Circuit is mutable. It must not also be value-hashable.
     # Defining __hash__ requires defining a FrozenCircuit variant instead.
     with pytest.raises(TypeError, match="unhashable"):
-        _ = hash(stim.Circuit())
+        _ = hash(lestim.Circuit())
 
 
 def test_circuit_generation():
-    surface_code_circuit = stim.Circuit.generated(
+    surface_code_circuit = lestim.Circuit.generated(
             "surface_code:rotated_memory_z",
             distance=5,
             rounds=10)
@@ -306,41 +306,41 @@ def test_circuit_generation():
 
 def test_circuit_generation_errors():
     with pytest.raises(ValueError, match="Known repetition_code tasks"):
-        stim.Circuit.generated(
+        lestim.Circuit.generated(
             "repetition_code:UNKNOWN",
             distance=3,
             rounds=1000)
     with pytest.raises(ValueError, match="Expected type to start with."):
-        stim.Circuit.generated(
+        lestim.Circuit.generated(
             "UNKNOWN:memory",
             distance=0,
             rounds=1000)
     with pytest.raises(ValueError, match="distance >= 2"):
-        stim.Circuit.generated(
+        lestim.Circuit.generated(
             "repetition_code:memory",
             distance=1,
             rounds=1000)
 
     with pytest.raises(ValueError, match="0 <= after_clifford_depolarization <= 1"):
-        stim.Circuit.generated(
+        lestim.Circuit.generated(
             "repetition_code:memory",
             distance=3,
             rounds=1000,
             after_clifford_depolarization=-1)
     with pytest.raises(ValueError, match="0 <= before_round_data_depolarization <= 1"):
-        stim.Circuit.generated(
+        lestim.Circuit.generated(
             "repetition_code:memory",
             distance=3,
             rounds=1000,
             before_round_data_depolarization=-1)
     with pytest.raises(ValueError, match="0 <= after_reset_flip_probability <= 1"):
-        stim.Circuit.generated(
+        lestim.Circuit.generated(
             "repetition_code:memory",
             distance=3,
             rounds=1000,
             after_reset_flip_probability=-1)
     with pytest.raises(ValueError, match="0 <= before_measure_flip_probability <= 1"):
-        stim.Circuit.generated(
+        lestim.Circuit.generated(
             "repetition_code:memory",
             distance=3,
             rounds=1000,
@@ -348,14 +348,14 @@ def test_circuit_generation_errors():
 
 
 def test_num_detectors():
-    assert stim.Circuit().num_detectors == 0
-    assert stim.Circuit("DETECTOR").num_detectors == 1
-    assert stim.Circuit("""
+    assert lestim.Circuit().num_detectors == 0
+    assert lestim.Circuit("DETECTOR").num_detectors == 1
+    assert lestim.Circuit("""
         REPEAT 1000 {
             DETECTOR
         }
     """).num_detectors == 1000
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         DETECTOR
         REPEAT 1000000 {
             REPEAT 1000000 {
@@ -367,10 +367,10 @@ def test_num_detectors():
 
 
 def test_num_observables():
-    assert stim.Circuit().num_observables == 0
-    assert stim.Circuit("OBSERVABLE_INCLUDE(0)").num_observables == 1
-    assert stim.Circuit("OBSERVABLE_INCLUDE(1)").num_observables == 2
-    assert stim.Circuit("""
+    assert lestim.Circuit().num_observables == 0
+    assert lestim.Circuit("OBSERVABLE_INCLUDE(0)").num_observables == 1
+    assert lestim.Circuit("OBSERVABLE_INCLUDE(1)").num_observables == 2
+    assert lestim.Circuit("""
         M 0
         OBSERVABLE_INCLUDE(2)
         REPEAT 1000000 {
@@ -384,7 +384,7 @@ def test_num_observables():
 
 
 def test_indexing_operations():
-    c = stim.Circuit()
+    c = lestim.Circuit()
     assert len(c) == 0
     assert list(c) == []
     with pytest.raises(IndexError):
@@ -392,16 +392,16 @@ def test_indexing_operations():
     with pytest.raises(IndexError):
         _ = c[-1]
 
-    c = stim.Circuit('X 0')
+    c = lestim.Circuit('X 0')
     assert len(c) == 1
-    assert list(c) == [stim.CircuitInstruction('X', [stim.GateTarget(0)])]
-    assert c[0] == c[-1] == stim.CircuitInstruction('X', [stim.GateTarget(0)])
+    assert list(c) == [lestim.CircuitInstruction('X', [lestim.GateTarget(0)])]
+    assert c[0] == c[-1] == lestim.CircuitInstruction('X', [lestim.GateTarget(0)])
     with pytest.raises(IndexError):
         _ = c[1]
     with pytest.raises(IndexError):
         _ = c[-2]
 
-    c = stim.Circuit('''
+    c = lestim.Circuit('''
         X 5 6
         REPEAT 1000 {
             H 5
@@ -414,14 +414,14 @@ def test_indexing_operations():
     with pytest.raises(IndexError):
         _ = c[-4]
     assert list(c) == [
-        stim.CircuitInstruction('X', [stim.GateTarget(5), stim.GateTarget(6)]),
-        stim.CircuitRepeatBlock(1000, stim.Circuit('H 5')),
-        stim.CircuitInstruction('M', [stim.GateTarget(stim.target_inv(0))]),
+        lestim.CircuitInstruction('X', [lestim.GateTarget(5), lestim.GateTarget(6)]),
+        lestim.CircuitRepeatBlock(1000, lestim.Circuit('H 5')),
+        lestim.CircuitInstruction('M', [lestim.GateTarget(lestim.target_inv(0))]),
     ]
 
 
 def test_slicing():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         H 0
         REPEAT 5 {
             X 1
@@ -431,17 +431,17 @@ def test_slicing():
     """)
     assert c[:] is not c
     assert c[:] == c
-    assert c[1:-1] == stim.Circuit("""
+    assert c[1:-1] == lestim.Circuit("""
         REPEAT 5 {
             X 1
         }
         Y 2
     """)
-    assert c[::2] == stim.Circuit("""
+    assert c[::2] == lestim.Circuit("""
         H 0
         Y 2
     """)
-    assert c[1::2] == stim.Circuit("""
+    assert c[1::2] == lestim.Circuit("""
         REPEAT 5 {
             X 1
         }
@@ -450,37 +450,37 @@ def test_slicing():
 
 
 def test_reappend_gate_targets():
-    expected = stim.Circuit("""
+    expected = lestim.Circuit("""
         MPP !X0 * X1
         CX rec[-1] 5
     """)
-    c = stim.Circuit()
-    c.append_operation("MPP", cast(stim.CircuitInstruction, expected[0]).targets_copy())
-    c.append_operation("CX", cast(stim.CircuitInstruction, expected[1]).targets_copy())
+    c = lestim.Circuit()
+    c.append_operation("MPP", cast(lestim.CircuitInstruction, expected[0]).targets_copy())
+    c.append_operation("CX", cast(lestim.CircuitInstruction, expected[1]).targets_copy())
     assert c == expected
 
 
 def test_append_instructions_and_blocks():
-    c = stim.Circuit()
+    c = lestim.Circuit()
 
     c.append_operation("TICK")
-    assert c == stim.Circuit("TICK")
+    assert c == lestim.Circuit("TICK")
 
     with pytest.raises(ValueError, match="no targets"):
         c.append_operation("TICK", [1, 2, 3])
 
-    c.append_operation(stim.Circuit("H 1")[0])
-    assert c == stim.Circuit("TICK\nH 1")
+    c.append_operation(lestim.Circuit("H 1")[0])
+    assert c == lestim.Circuit("TICK\nH 1")
 
-    c.append_operation(stim.Circuit("CX 1 2 3 4")[0])
-    assert c == stim.Circuit("""
+    c.append_operation(lestim.Circuit("CX 1 2 3 4")[0])
+    assert c == lestim.Circuit("""
         TICK
         H 1
         CX 1 2 3 4
     """)
 
-    c.append_operation((stim.Circuit("X 5") * 100)[0])
-    assert c == stim.Circuit("""
+    c.append_operation((lestim.Circuit("X 5") * 100)[0])
+    assert c == lestim.Circuit("""
         TICK
         H 1
         CX 1 2 3 4
@@ -489,8 +489,8 @@ def test_append_instructions_and_blocks():
         }
     """)
 
-    c.append_operation(stim.Circuit("PAULI_CHANNEL_1(0.125, 0.25, 0.325) 4 5 6")[0])
-    assert c == stim.Circuit("""
+    c.append_operation(lestim.Circuit("PAULI_CHANNEL_1(0.125, 0.25, 0.325) 4 5 6")[0])
+    assert c == lestim.Circuit("""
         TICK
         H 1
         CX 1 2 3 4
@@ -504,23 +504,23 @@ def test_append_instructions_and_blocks():
         c.append_operation(object())
 
     with pytest.raises(ValueError, match="targets"):
-        c.append_operation(stim.Circuit("H 1")[0], [2])
+        c.append_operation(lestim.Circuit("H 1")[0], [2])
 
     with pytest.raises(ValueError, match="arg"):
-        c.append_operation(stim.Circuit("H 1")[0], [], 0.1)
+        c.append_operation(lestim.Circuit("H 1")[0], [], 0.1)
 
     with pytest.raises(ValueError, match="targets"):
-        c.append_operation((stim.Circuit("H 1") * 5)[0], [2])
+        c.append_operation((lestim.Circuit("H 1") * 5)[0], [2])
 
     with pytest.raises(ValueError, match="arg"):
-        c.append_operation((stim.Circuit("H 1") * 5)[0], [], 0.1)
+        c.append_operation((lestim.Circuit("H 1") * 5)[0], [], 0.1)
 
     with pytest.raises(ValueError, match="repeat 0"):
-        c.append_operation(stim.CircuitRepeatBlock(0, stim.Circuit("H 1")))
+        c.append_operation(lestim.CircuitRepeatBlock(0, lestim.Circuit("H 1")))
 
 
 def test_circuit_measurement_sampling_seeded():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         H 0
         M 0
     """)
@@ -545,7 +545,7 @@ def test_circuit_measurement_sampling_seeded():
 
 
 def test_circuit_detector_sampling_seeded():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         X_ERROR(0.5) 0
         M 0
         DETECTOR rec[-1]
@@ -571,24 +571,24 @@ def test_circuit_detector_sampling_seeded():
 
 
 def test_approx_equals():
-    base = stim.Circuit("X_ERROR(0.099) 0")
-    assert not base.approx_equals(stim.Circuit("X_ERROR(0.101) 0"), atol=0)
-    assert not base.approx_equals(stim.Circuit("X_ERROR(0.101) 0"), atol=0.00001)
-    assert base.approx_equals(stim.Circuit("X_ERROR(0.101) 0"), atol=0.01)
-    assert base.approx_equals(stim.Circuit("X_ERROR(0.101) 0"), atol=999)
-    assert not base.approx_equals(stim.Circuit("DEPOLARIZE1(0.101) 0"), atol=999)
+    base = lestim.Circuit("X_ERROR(0.099) 0")
+    assert not base.approx_equals(lestim.Circuit("X_ERROR(0.101) 0"), atol=0)
+    assert not base.approx_equals(lestim.Circuit("X_ERROR(0.101) 0"), atol=0.00001)
+    assert base.approx_equals(lestim.Circuit("X_ERROR(0.101) 0"), atol=0.01)
+    assert base.approx_equals(lestim.Circuit("X_ERROR(0.101) 0"), atol=999)
+    assert not base.approx_equals(lestim.Circuit("DEPOLARIZE1(0.101) 0"), atol=999)
 
     assert not base.approx_equals(object(), atol=999)
-    assert not base.approx_equals(stim.PauliString("XYZ"), atol=999)
+    assert not base.approx_equals(lestim.PauliString("XYZ"), atol=999)
 
 
 def test_append_extended_cases():
-    c = stim.Circuit()
+    c = lestim.Circuit()
     c.append("H", 5)
     c.append("CNOT", [0, 1])
     c.append("H", c[0].targets_copy()[0])
     c.append("X", (e + 1 for e in range(5)))
-    assert c == stim.Circuit("""
+    assert c == lestim.Circuit("""
         H 5
         CNOT 0 1
         H 5
@@ -599,7 +599,7 @@ def test_append_extended_cases():
 def test_pickle():
     import pickle
 
-    t = stim.Circuit("""
+    t = lestim.Circuit("""
         H 0
         REPEAT 100 {
             M 0
@@ -611,28 +611,28 @@ def test_pickle():
 
 
 def test_backwards_compatibility_vs_safety_append_vs_append_operation():
-    c = stim.Circuit()
+    c = lestim.Circuit()
     with pytest.raises(ValueError, match="takes 1 parens argument"):
         c.append("X_ERROR", [5])
     with pytest.raises(ValueError, match="takes 1 parens argument"):
         c.append("OBSERVABLE_INCLUDE", [])
-    assert c == stim.Circuit()
+    assert c == lestim.Circuit()
     c.append_operation("X_ERROR", [5])
-    assert c == stim.Circuit("X_ERROR(0) 5")
+    assert c == lestim.Circuit("X_ERROR(0) 5")
     c.append_operation("Z_ERROR", [5], 0.25)
-    assert c == stim.Circuit("X_ERROR(0) 5\nZ_ERROR(0.25) 5")
+    assert c == lestim.Circuit("X_ERROR(0) 5\nZ_ERROR(0.25) 5")
 
 
 def test_anti_commuting_mpp_error_message():
     with pytest.raises(ValueError, match="while analyzing a Pauli product measurement"):
-        stim.Circuit("""
+        lestim.Circuit("""
             MPP X0 Z0
             DETECTOR rec[-1]
         """).detector_error_model()
 
 
 def test_blocked_remnant_edge_error():
-    circuit = stim.Circuit("""
+    circuit = lestim.Circuit("""
         X_ERROR(0.125) 0
         CORRELATED_ERROR(0.25) X0 X1
         M 0 1
@@ -642,7 +642,7 @@ def test_blocked_remnant_edge_error():
         DETECTOR rec[-2]
     """)
 
-    assert circuit.detector_error_model(decompose_errors=True) == stim.DetectorErrorModel("""
+    assert circuit.detector_error_model(decompose_errors=True) == lestim.DetectorErrorModel("""
         error(0.125) D2 D3
         error(0.25) D2 D3 ^ D0 D1
     """)
@@ -655,14 +655,14 @@ def test_blocked_remnant_edge_error():
     assert circuit.detector_error_model(
         decompose_errors=True,
         block_decomposition_from_introducing_remnant_edges=True,
-        ignore_decomposition_failures=True) == stim.DetectorErrorModel("""
+        ignore_decomposition_failures=True) == lestim.DetectorErrorModel("""
             error(0.25) D0 D1 D2 D3
             error(0.125) D2 D3
         """)
 
 
 def test_shortest_graphlike_error():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         TICK
         X_ERROR(0.125) 0
         Y_ERROR(0.125) 0
@@ -672,7 +672,7 @@ def test_shortest_graphlike_error():
 
     actual = c.shortest_graphlike_error()
     assert len(actual) == 1
-    assert isinstance(actual[0], stim.ExplainedError)
+    assert isinstance(actual[0], lestim.ExplainedError)
     assert str(actual[0]) == """ExplainedError {
     dem_error_terms: L0
     CircuitErrorLocation {
@@ -695,7 +695,7 @@ def test_shortest_graphlike_error():
 
     actual = c.shortest_graphlike_error(canonicalize_circuit_errors=True)
     assert len(actual) == 1
-    assert isinstance(actual[0], stim.ExplainedError)
+    assert isinstance(actual[0], lestim.ExplainedError)
     assert str(actual[0]) == """ExplainedError {
     dem_error_terms: L0
     CircuitErrorLocation {
@@ -711,7 +711,7 @@ def test_shortest_graphlike_error():
 
 def test_shortest_graphlike_error_empty():
     with pytest.raises(ValueError, match="Failed to find"):
-        stim.Circuit().shortest_graphlike_error()
+        lestim.Circuit().shortest_graphlike_error()
 
 
 def test_shortest_graphlike_error_msgs():
@@ -719,16 +719,16 @@ def test_shortest_graphlike_error_msgs():
             ValueError,
             match="NO OBSERVABLES"
     ):
-        stim.Circuit().shortest_graphlike_error()
+        lestim.Circuit().shortest_graphlike_error()
 
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         M 0
         OBSERVABLE_INCLUDE(0) rec[-1]
     """)
     with pytest.raises(ValueError, match="NO DETECTORS"):
         c.shortest_graphlike_error()
 
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         X_ERROR(0.1) 0
         M 0
     """)
@@ -737,7 +737,7 @@ def test_shortest_graphlike_error_msgs():
     with pytest.raises(ValueError, match=""):
         c.shortest_graphlike_error()
 
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         M 0
         DETECTOR rec[-1]
         OBSERVABLE_INCLUDE(0) rec[-1]
@@ -745,7 +745,7 @@ def test_shortest_graphlike_error_msgs():
     with pytest.raises(ValueError, match="NO ERRORS"):
         c.shortest_graphlike_error()
 
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         M(0.1) 0
         DETECTOR rec[-1]
         DETECTOR rec[-1]
@@ -755,7 +755,7 @@ def test_shortest_graphlike_error_msgs():
     with pytest.raises(ValueError, match="NO GRAPHLIKE ERRORS"):
         c.shortest_graphlike_error()
 
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         X_ERROR(0.1) 0
         M 0
         DETECTOR rec[-1]
@@ -766,7 +766,7 @@ def test_shortest_graphlike_error_msgs():
 
 def test_search_for_undetectable_logical_errors_empty():
     with pytest.raises(ValueError, match="Failed to find"):
-        stim.Circuit().search_for_undetectable_logical_errors(
+        lestim.Circuit().search_for_undetectable_logical_errors(
             dont_explore_edges_increasing_symptom_degree=True,
             dont_explore_edges_with_degree_above=4,
             dont_explore_detection_event_sets_with_size_above=4,
@@ -775,13 +775,13 @@ def test_search_for_undetectable_logical_errors_empty():
 
 def test_search_for_undetectable_logical_errors_msgs():
     with pytest.raises(ValueError, match=r"NO OBSERVABLES(.|\n)*NO DETECTORS"):
-        stim.Circuit().search_for_undetectable_logical_errors(
+        lestim.Circuit().search_for_undetectable_logical_errors(
             dont_explore_edges_increasing_symptom_degree=True,
             dont_explore_edges_with_degree_above=4,
             dont_explore_detection_event_sets_with_size_above=4,
         )
 
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         M 0
         OBSERVABLE_INCLUDE(0) rec[-1]
     """)
@@ -792,7 +792,7 @@ def test_search_for_undetectable_logical_errors_msgs():
             dont_explore_detection_event_sets_with_size_above=4,
         )
 
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         X_ERROR(0.1) 0
         M 0
     """)
@@ -803,7 +803,7 @@ def test_search_for_undetectable_logical_errors_msgs():
             dont_explore_detection_event_sets_with_size_above=4,
         )
 
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         M 0
         DETECTOR rec[-1]
         OBSERVABLE_INCLUDE(0) rec[-1]
@@ -815,7 +815,7 @@ def test_search_for_undetectable_logical_errors_msgs():
             dont_explore_detection_event_sets_with_size_above=4,
         )
 
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         X_ERROR(0.1) 0
         M 0
         DETECTOR rec[-1]
@@ -829,7 +829,7 @@ def test_search_for_undetectable_logical_errors_msgs():
 
 
 def test_shortest_error_sat_problem_unrecognized_format():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         X_ERROR(0.1) 0
         M 0
         OBSERVABLE_INCLUDE(0) rec[-1]
@@ -842,7 +842,7 @@ def test_shortest_error_sat_problem_unrecognized_format():
 
 
 def test_shortest_error_sat_problem():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         X_ERROR(0.1) 0
         M 0
         OBSERVABLE_INCLUDE(0) rec[-1]
@@ -855,7 +855,7 @@ def test_shortest_error_sat_problem():
 
 
 def test_likeliest_error_sat_problem():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         X_ERROR(0.1) 0
         M 0
         OBSERVABLE_INCLUDE(0) rec[-1]
@@ -868,7 +868,7 @@ def test_likeliest_error_sat_problem():
 
 
 def test_shortest_graphlike_error_ignore():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         TICK
         X_ERROR(0.125) 0
         M 0
@@ -883,7 +883,7 @@ def test_shortest_graphlike_error_ignore():
 
 
 def test_coords():
-    circuit = stim.Circuit("""
+    circuit = lestim.Circuit("""
         QUBIT_COORDS(1, 2, 3) 0
         QUBIT_COORDS(2) 1
         SHIFT_COORDS(5)
@@ -897,7 +897,7 @@ def test_coords():
 
 
 def test_explain_errors():
-    circuit = stim.Circuit("""
+    circuit = lestim.Circuit("""
         H 0
         CNOT 0 1
         DEPOLARIZE1(0.01) 0
@@ -944,7 +944,7 @@ def test_explain_errors():
 }"""
 
     r = circuit.explain_detector_error_model_errors(
-        dem_filter=stim.DetectorErrorModel('error(1) D0 D1'),
+        dem_filter=lestim.DetectorErrorModel('error(1) D0 D1'),
         reduce_to_one_representative_error=True,
     )
     assert len(r) == 1
@@ -962,7 +962,7 @@ def test_explain_errors():
 
 
 def test_without_noise():
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         X_ERROR(0.25) 0
         CNOT 0 1
         M(0.125) 0
@@ -970,7 +970,7 @@ def test_without_noise():
             DEPOLARIZE1(0.25) 0 1 2
             X 0 1 2
         }
-    """).without_noise() == stim.Circuit("""
+    """).without_noise() == lestim.Circuit("""
         CNOT 0 1
         M 0
         REPEAT 50 {
@@ -980,7 +980,7 @@ def test_without_noise():
 
 
 def test_flattened():
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         SHIFT_COORDS(5, 0)
         QUBIT_COORDS(1, 2, 3) 0
         REPEAT 5 {
@@ -989,7 +989,7 @@ def test_flattened():
             DETECTOR(1, 0) rec[-1]
             SHIFT_COORDS(0, 1)
         }
-    """).flattened() == stim.Circuit("""
+    """).flattened() == lestim.Circuit("""
         QUBIT_COORDS(6, 2, 3) 0
         MR 0 1
         DETECTOR(5, 0) rec[-2]
@@ -1011,51 +1011,51 @@ def test_flattened():
 
 def test_complex_slice_does_not_seg_fault():
     with pytest.raises(TypeError):
-        _ = stim.Circuit()[1j]
+        _ = lestim.Circuit()[1j]
 
 
 def test_circuit_from_file():
     with tempfile.TemporaryDirectory() as tmpdir:
-        path = tmpdir + '/tmp.stim'
+        path = tmpdir + '/tmp.lestim'
         with open(path, 'w') as f:
             print('H 5', file=f)
-        assert stim.Circuit.from_file(path) == stim.Circuit('H 5')
+        assert lestim.Circuit.from_file(path) == lestim.Circuit('H 5')
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        path = pathlib.Path(tmpdir) / 'tmp.stim'
+        path = pathlib.Path(tmpdir) / 'tmp.lestim'
         with open(path, 'w') as f:
             print('H 5', file=f)
-        assert stim.Circuit.from_file(path) == stim.Circuit('H 5')
+        assert lestim.Circuit.from_file(path) == lestim.Circuit('H 5')
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        path = tmpdir + '/tmp.stim'
+        path = tmpdir + '/tmp.lestim'
         with open(path, 'w') as f:
             print('CNOT 4 5', file=f)
         with open(path) as f:
-            assert stim.Circuit.from_file(f) == stim.Circuit('CX 4 5')
+            assert lestim.Circuit.from_file(f) == lestim.Circuit('CX 4 5')
 
     with pytest.raises(ValueError, match="how to read"):
-        stim.Circuit.from_file(object())
+        lestim.Circuit.from_file(object())
     with pytest.raises(ValueError, match="how to read"):
-        stim.Circuit.from_file(123)
+        lestim.Circuit.from_file(123)
 
 
 def test_circuit_to_file():
-    c = stim.Circuit('H 5\ncnot 0 1')
+    c = lestim.Circuit('H 5\ncnot 0 1')
     with tempfile.TemporaryDirectory() as tmpdir:
-        path = tmpdir + '/tmp.stim'
+        path = tmpdir + '/tmp.lestim'
         c.to_file(path)
         with open(path) as f:
             assert f.read() == 'H 5\nCX 0 1\n'
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        path = pathlib.Path(tmpdir) / 'tmp.stim'
+        path = pathlib.Path(tmpdir) / 'tmp.lestim'
         c.to_file(path)
         with open(path) as f:
             assert f.read() == 'H 5\nCX 0 1\n'
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        path = tmpdir + '/tmp.stim'
+        path = tmpdir + '/tmp.lestim'
         with open(path, 'w') as f:
             c.to_file(f)
         with open(path) as f:
@@ -1068,7 +1068,7 @@ def test_circuit_to_file():
 
 
 def test_diagram():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         H 0
         CX 0 1
     """)
@@ -1079,7 +1079,7 @@ q1: ---X-
     """.strip()
     assert str(c.diagram(type='timeline-text')) == str(c.diagram())
 
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         H 0
         CNOT 0 1
         TICK
@@ -1092,7 +1092,7 @@ q0: -Z:D0-
 q1: -Z:D0-
     """.strip()
 
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         H 0
         CNOT 0 1 0 2
         TICK
@@ -1143,24 +1143,24 @@ q2: ------
 
 
 def test_circuit_inverse():
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         S 0 1
         CX 0 1 0 2
-    """).inverse() == stim.Circuit("""
+    """).inverse() == lestim.Circuit("""
         CX 0 2 0 1
         S_DAG 1 0
     """)
 
 
 def test_circuit_slice_reverse():
-    c = stim.Circuit()
-    assert c[::-1] == stim.Circuit()
-    c = stim.Circuit("X 1\nY 2\nZ 3")
-    assert c[::-1] == stim.Circuit("Z 3\nY 2\nX 1")
+    c = lestim.Circuit()
+    assert c[::-1] == lestim.Circuit()
+    c = lestim.Circuit("X 1\nY 2\nZ 3")
+    assert c[::-1] == lestim.Circuit("Z 3\nY 2\nX 1")
 
 
 def test_with_inlined_feedback_bad_end_eats_into_loop():
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         CX 0 1
         M 1
         CX rec[-1] 1
@@ -1168,7 +1168,7 @@ def test_with_inlined_feedback_bad_end_eats_into_loop():
         M 1
         DETECTOR rec[-1] rec[-2]
         OBSERVABLE_INCLUDE(0) rec[-1]
-    """).with_inlined_feedback() == stim.Circuit("""
+    """).with_inlined_feedback() == lestim.Circuit("""
         CX 0 1
         M 1
         OBSERVABLE_INCLUDE(0) rec[-1]
@@ -1178,7 +1178,7 @@ def test_with_inlined_feedback_bad_end_eats_into_loop():
         OBSERVABLE_INCLUDE(0) rec[-1]
     """)
 
-    before = stim.Circuit("""
+    before = lestim.Circuit("""
         R 0 1 2 3 4 5 6
 
         X_ERROR(0.125) 0 1 2 3 4 5 6
@@ -1234,7 +1234,7 @@ def test_with_inlined_feedback_bad_end_eats_into_loop():
         OBSERVABLE_INCLUDE(0) rec[-1]
     """)
     after = before.with_inlined_feedback()
-    assert after == stim.Circuit("""
+    assert after == lestim.Circuit("""
         R 0 1 2 3 4 5 6
 
         X_ERROR(0.125) 0 1 2 3 4 5 6
@@ -1324,7 +1324,7 @@ def test_with_inlined_feedback_bad_end_eats_into_loop():
 
 
 def test_with_inlined_feedback():
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         CX 0 1
         M 1
         CX rec[-1] 1
@@ -1332,7 +1332,7 @@ def test_with_inlined_feedback():
         M 1
         DETECTOR rec[-1] rec[-2]
         OBSERVABLE_INCLUDE(0) rec[-1]
-    """).with_inlined_feedback() == stim.Circuit("""
+    """).with_inlined_feedback() == lestim.Circuit("""
         CX 0 1
         M 1
         OBSERVABLE_INCLUDE(0) rec[-1]
@@ -1342,7 +1342,7 @@ def test_with_inlined_feedback():
         OBSERVABLE_INCLUDE(0) rec[-1]
     """)
 
-    before = stim.Circuit("""
+    before = lestim.Circuit("""
         R 0 1 2 3 4 5 6
 
         X_ERROR(0.125) 0 1 2 3 4 5 6
@@ -1398,7 +1398,7 @@ def test_with_inlined_feedback():
         OBSERVABLE_INCLUDE(0) rec[-1]
     """)
     after = before.with_inlined_feedback()
-    assert str(after) == str(stim.Circuit("""
+    assert str(after) == str(lestim.Circuit("""
         R 0 1 2 3 4 5 6
 
         X_ERROR(0.125) 0 1 2 3 4 5 6
@@ -1472,13 +1472,13 @@ def test_with_inlined_feedback():
 
 
 def test_detslice_ops_diagram_no_ticks_does_not_hang():
-    assert stim.Circuit.generated("surface_code:rotated_memory_x", rounds=5, distance=5).diagram("detslice-svg") is not None
+    assert lestim.Circuit.generated("surface_code:rotated_memory_x", rounds=5, distance=5).diagram("detslice-svg") is not None
 
 
 def test_num_ticks():
-    assert stim.Circuit().num_ticks == 0
-    assert stim.Circuit("TICK").num_ticks == 1
-    assert stim.Circuit("""
+    assert lestim.Circuit().num_ticks == 0
+    assert lestim.Circuit("TICK").num_ticks == 1
+    assert lestim.Circuit("""
         TICK
         REPEAT 100 {
             TICK
@@ -1488,7 +1488,7 @@ def test_num_ticks():
             }
         }
     """).num_ticks == 1201
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         H 0
         TICK
         CX 0 1
@@ -1497,7 +1497,7 @@ def test_num_ticks():
 
 
 def test_reference_sample():
-    circuit = stim.Circuit(
+    circuit = lestim.Circuit(
         """
         H 0
         CNOT 0 1
@@ -1505,7 +1505,7 @@ def test_reference_sample():
     )
     ref = circuit.reference_sample()
     assert len(ref) == 0
-    circuit = stim.Circuit(
+    circuit = lestim.Circuit(
         """
         H 0 1
         CX 0 2 1 3
@@ -1525,7 +1525,7 @@ def test_reference_sample():
 
 
 def test_max_mix_depolarization_is_allowed_in_dem_conversion_without_args():
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         H 0
         CX 0 1
         DEPOLARIZE1(0.75) 0
@@ -1534,13 +1534,13 @@ def test_max_mix_depolarization_is_allowed_in_dem_conversion_without_args():
         M 0 1
         DETECTOR rec[-1]
         DETECTOR rec[-2]
-    """).detector_error_model(approximate_disjoint_errors=True) == stim.DetectorErrorModel("""
+    """).detector_error_model(approximate_disjoint_errors=True) == lestim.DetectorErrorModel("""
         error(0.5) D0
         error(0.5) D0 D1
         error(0.5) D1
     """)
 
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         H 0 1
         CX 0 2 1 3
         DEPOLARIZE2(0.9375) 0 1
@@ -1551,7 +1551,7 @@ def test_max_mix_depolarization_is_allowed_in_dem_conversion_without_args():
         DETECTOR rec[-2]
         DETECTOR rec[-3]
         DETECTOR rec[-4]
-    """).detector_error_model() == stim.DetectorErrorModel("""
+    """).detector_error_model() == lestim.DetectorErrorModel("""
         error(0.5) D0
         error(0.5) D0 D1
         error(0.5) D0 D1 D2
@@ -1571,7 +1571,7 @@ def test_max_mix_depolarization_is_allowed_in_dem_conversion_without_args():
 
 
 def test_shortest_graphlike_error_many_obs():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         MPP Z0*Z1 Z1*Z2 Z2*Z3 Z3*Z4
         X_ERROR(0.1) 0 1 2 3 4
         MPP Z0*Z1 Z1*Z2 Z2*Z3 Z3*Z4
@@ -1586,9 +1586,9 @@ def test_shortest_graphlike_error_many_obs():
 
 
 def test_detslice_filter_coords_flexibility():
-    c = stim.Circuit.generated("repetition_code:memory", distance=3, rounds=3)
-    d1 = c.diagram("detslice", filter_coords=[stim.DemTarget.relative_detector_id(1)])
-    d2 = c.diagram("detslice-svg", filter_coords=stim.DemTarget.relative_detector_id(1))
+    c = lestim.Circuit.generated("repetition_code:memory", distance=3, rounds=3)
+    d1 = c.diagram("detslice", filter_coords=[lestim.DemTarget.relative_detector_id(1)])
+    d2 = c.diagram("detslice-svg", filter_coords=lestim.DemTarget.relative_detector_id(1))
     d3 = c.diagram("detslice", filter_coords=["D1"])
     d4 = c.diagram("detslice", filter_coords="D1")
     d5 = c.diagram("detector-slice-svg", filter_coords=[3, 0])
@@ -1600,7 +1600,7 @@ def test_detslice_filter_coords_flexibility():
     assert str(d1) == str(d6)
     assert str(d1) != str(c.diagram("detslice", filter_coords="L0"))
 
-    d1 = c.diagram("detslice", filter_coords=[stim.DemTarget.relative_detector_id(1), stim.DemTarget.relative_detector_id(3), stim.DemTarget.relative_detector_id(5), "D7"])
+    d1 = c.diagram("detslice", filter_coords=[lestim.DemTarget.relative_detector_id(1), lestim.DemTarget.relative_detector_id(3), lestim.DemTarget.relative_detector_id(5), "D7"])
     d2 = c.diagram("detslice", filter_coords=["D1", "D3", "D5", "D7"])
     d3 = c.diagram("detslice-svg", filter_coords=[3,])
     d4 = c.diagram("detslice-svg", filter_coords=[[3,]])
@@ -1612,51 +1612,51 @@ def test_detslice_filter_coords_flexibility():
 
 
 def test_has_flow_ry():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         RY 0
     """)
-    assert c.has_flow(stim.Flow("1 -> Y"))
-    assert not c.has_flow(stim.Flow("1 -> -Y"))
-    assert not c.has_flow(stim.Flow("1 -> X"))
-    assert c.has_flow(stim.Flow("1 -> Y"), unsigned=True)
-    assert not c.has_flow(stim.Flow("1 -> X"), unsigned=True)
-    assert c.has_flow(stim.Flow("1 -> -Y"), unsigned=True)
+    assert c.has_flow(lestim.Flow("1 -> Y"))
+    assert not c.has_flow(lestim.Flow("1 -> -Y"))
+    assert not c.has_flow(lestim.Flow("1 -> X"))
+    assert c.has_flow(lestim.Flow("1 -> Y"), unsigned=True)
+    assert not c.has_flow(lestim.Flow("1 -> X"), unsigned=True)
+    assert c.has_flow(lestim.Flow("1 -> -Y"), unsigned=True)
 
 
 def test_has_flow_cxs():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         CX 0 1
         S 0
     """)
 
-    assert c.has_flow(stim.Flow("X_ -> YX"))
-    assert c.has_flow(stim.Flow("Y_ -> -XX"))
-    assert not c.has_flow(stim.Flow("X_ -> XX"))
-    assert not c.has_flow(stim.Flow("X_ -> -XX"))
+    assert c.has_flow(lestim.Flow("X_ -> YX"))
+    assert c.has_flow(lestim.Flow("Y_ -> -XX"))
+    assert not c.has_flow(lestim.Flow("X_ -> XX"))
+    assert not c.has_flow(lestim.Flow("X_ -> -XX"))
 
-    assert c.has_flow(stim.Flow("X_ -> YX"), unsigned=True)
-    assert c.has_flow(stim.Flow("Y_ -> -XX"), unsigned=True)
-    assert not c.has_flow(stim.Flow("X_ -> XX"), unsigned=True)
-    assert not c.has_flow(stim.Flow("X_ -> -XX"), unsigned=True)
+    assert c.has_flow(lestim.Flow("X_ -> YX"), unsigned=True)
+    assert c.has_flow(lestim.Flow("Y_ -> -XX"), unsigned=True)
+    assert not c.has_flow(lestim.Flow("X_ -> XX"), unsigned=True)
+    assert not c.has_flow(lestim.Flow("X_ -> -XX"), unsigned=True)
 
 
 def test_has_flow_cxm():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         CX 0 1
         M 1
     """)
-    assert c.has_flow(stim.Flow("1 -> _Z xor rec[0]"))
-    assert c.has_flow(stim.Flow("ZZ -> rec[0]"))
-    assert c.has_flow(stim.Flow("ZZ -> _Z"))
-    assert c.has_flow(stim.Flow("XX -> X_"))
-    assert c.has_flow(stim.Flow("1 -> _Z xor rec[0]"), unsigned=True)
-    assert c.has_flow(stim.Flow("ZZ -> rec[0]"), unsigned=True)
-    assert c.has_flow(stim.Flow("ZZ -> _Z"), unsigned=True)
-    assert c.has_flow(stim.Flow("XX -> X_"), unsigned=True)
+    assert c.has_flow(lestim.Flow("1 -> _Z xor rec[0]"))
+    assert c.has_flow(lestim.Flow("ZZ -> rec[0]"))
+    assert c.has_flow(lestim.Flow("ZZ -> _Z"))
+    assert c.has_flow(lestim.Flow("XX -> X_"))
+    assert c.has_flow(lestim.Flow("1 -> _Z xor rec[0]"), unsigned=True)
+    assert c.has_flow(lestim.Flow("ZZ -> rec[0]"), unsigned=True)
+    assert c.has_flow(lestim.Flow("ZZ -> _Z"), unsigned=True)
+    assert c.has_flow(lestim.Flow("XX -> X_"), unsigned=True)
 
 
 def test_has_flow_lattice_surgery():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         # Lattice surgery CNOT with feedback.
         RX 2
         MZZ 2 0
@@ -1667,20 +1667,20 @@ def test_has_flow_lattice_surgery():
 
         S 0
     """)
-    assert c.has_flow(stim.Flow("X_ -> YX"))
-    assert c.has_flow(stim.Flow("Z_ -> Z_"))
-    assert c.has_flow(stim.Flow("_X -> _X"))
-    assert c.has_flow(stim.Flow("_Z -> ZZ"))
-    assert not c.has_flow(stim.Flow("X_ -> XX"))
+    assert c.has_flow(lestim.Flow("X_ -> YX"))
+    assert c.has_flow(lestim.Flow("Z_ -> Z_"))
+    assert c.has_flow(lestim.Flow("_X -> _X"))
+    assert c.has_flow(lestim.Flow("_Z -> ZZ"))
+    assert not c.has_flow(lestim.Flow("X_ -> XX"))
 
-    assert not c.has_flow(stim.Flow("X_ -> XX"))
-    assert not c.has_flow(stim.Flow("X_ -> -YX"))
-    assert not c.has_flow(stim.Flow("X_ -> XX"), unsigned=True)
-    assert c.has_flow(stim.Flow("X_ -> -YX"), unsigned=True)
+    assert not c.has_flow(lestim.Flow("X_ -> XX"))
+    assert not c.has_flow(lestim.Flow("X_ -> -YX"))
+    assert not c.has_flow(lestim.Flow("X_ -> XX"), unsigned=True)
+    assert c.has_flow(lestim.Flow("X_ -> -YX"), unsigned=True)
 
 
 def test_has_flow_lattice_surgery_without_feedback():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         # Lattice surgery CNOT without feedback.
         RX 2
         MZZ 2 0
@@ -1689,58 +1689,58 @@ def test_has_flow_lattice_surgery_without_feedback():
 
         S 0
     """)
-    assert c.has_flow(stim.Flow("X_ -> YX xor rec[1]"))
-    assert c.has_flow(stim.Flow("Z_ -> Z_"))
-    assert c.has_flow(stim.Flow("_X -> _X"))
-    assert c.has_flow(stim.Flow("_Z -> ZZ xor rec[0] xor rec[2]"))
-    assert not c.has_flow(stim.Flow("X_ -> XX"))
+    assert c.has_flow(lestim.Flow("X_ -> YX xor rec[1]"))
+    assert c.has_flow(lestim.Flow("Z_ -> Z_"))
+    assert c.has_flow(lestim.Flow("_X -> _X"))
+    assert c.has_flow(lestim.Flow("_Z -> ZZ xor rec[0] xor rec[2]"))
+    assert not c.has_flow(lestim.Flow("X_ -> XX"))
     assert c.has_all_flows([])
     assert c.has_all_flows([
-        stim.Flow("X_ -> YX xor rec[1]"),
-        stim.Flow("Z_ -> Z_"),
+        lestim.Flow("X_ -> YX xor rec[1]"),
+        lestim.Flow("Z_ -> Z_"),
     ])
     assert not c.has_all_flows([
-        stim.Flow("X_ -> YX xor rec[1]"),
-        stim.Flow("Z_ -> Z_"),
-        stim.Flow("X_ -> XX"),
+        lestim.Flow("X_ -> YX xor rec[1]"),
+        lestim.Flow("Z_ -> Z_"),
+        lestim.Flow("X_ -> XX"),
     ])
 
-    assert not c.has_flow(stim.Flow("X_ -> XX"))
-    assert not c.has_flow(stim.Flow("X_ -> -YX"))
-    assert not c.has_flow(stim.Flow("X_ -> XX"), unsigned=True)
-    assert c.has_flow(stim.Flow("X_ -> -YX xor rec[1]"), unsigned=True)
+    assert not c.has_flow(lestim.Flow("X_ -> XX"))
+    assert not c.has_flow(lestim.Flow("X_ -> -YX"))
+    assert not c.has_flow(lestim.Flow("X_ -> XX"), unsigned=True)
+    assert c.has_flow(lestim.Flow("X_ -> -YX xor rec[1]"), unsigned=True)
 
 
 def test_has_flow_shorthands():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         MZ 99
         MXX 1 99
         MZZ 0 99
         MX 99
     """)
 
-    assert c.has_flow(stim.Flow("X_ -> XX xor rec[1] xor rec[3]"))
-    assert c.has_flow(stim.Flow("Z_ -> Z_"))
-    assert c.has_flow(stim.Flow("_X -> _X"))
-    assert c.has_flow(stim.Flow("_Z -> ZZ xor rec[0] xor rec[2]"))
+    assert c.has_flow(lestim.Flow("X_ -> XX xor rec[1] xor rec[3]"))
+    assert c.has_flow(lestim.Flow("Z_ -> Z_"))
+    assert c.has_flow(lestim.Flow("_X -> _X"))
+    assert c.has_flow(lestim.Flow("_Z -> ZZ xor rec[0] xor rec[2]"))
 
-    assert c.has_flow(stim.Flow("X_ -> XX xor rec[1] xor rec[3]"))
-    assert not c.has_flow(stim.Flow("Z_ -> -Z_"))
-    assert not c.has_flow(stim.Flow("-Z_ -> Z_"))
-    assert not c.has_flow(stim.Flow("Z_ -> X_"))
-    assert c.has_flow(stim.Flow("iX_ -> iXX xor rec[1] xor rec[3]"))
-    assert not c.has_flow(stim.Flow("-iX_ -> iXX xor rec[1] xor rec[3]"))
-    assert c.has_flow(stim.Flow("-iX_ -> -iXX xor rec[1] xor rec[3]"))
+    assert c.has_flow(lestim.Flow("X_ -> XX xor rec[1] xor rec[3]"))
+    assert not c.has_flow(lestim.Flow("Z_ -> -Z_"))
+    assert not c.has_flow(lestim.Flow("-Z_ -> Z_"))
+    assert not c.has_flow(lestim.Flow("Z_ -> X_"))
+    assert c.has_flow(lestim.Flow("iX_ -> iXX xor rec[1] xor rec[3]"))
+    assert not c.has_flow(lestim.Flow("-iX_ -> iXX xor rec[1] xor rec[3]"))
+    assert c.has_flow(lestim.Flow("-iX_ -> -iXX xor rec[1] xor rec[3]"))
     with pytest.raises(ValueError, match="Anti-Hermitian"):
-        stim.Flow("iX_ -> XX")
+        lestim.Flow("iX_ -> XX")
 
 
 def test_decomposed():
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         ISWAP 0 1 2 1
         TICK
         MPP X1*Z2*Y3
-    """).decomposed() == stim.Circuit("""
+    """).decomposed() == lestim.Circuit("""
         H 0
         CX 0 1 1 0
         H 1
@@ -1766,7 +1766,7 @@ def test_decomposed():
 
 
 def test_detecting_regions():
-    assert stim.Circuit('''
+    assert lestim.Circuit('''
         R 0
         TICK
         H 0
@@ -1775,25 +1775,25 @@ def test_detecting_regions():
         TICK
         MX 0 1
         DETECTOR rec[-1] rec[-2]
-    ''').detecting_regions() == {stim.DemTarget.relative_detector_id(0): {
-        0: stim.PauliString("Z_"),
-        1: stim.PauliString("X_"),
-        2: stim.PauliString("XX"),
+    ''').detecting_regions() == {lestim.DemTarget.relative_detector_id(0): {
+        0: lestim.PauliString("Z_"),
+        1: lestim.PauliString("X_"),
+        2: lestim.PauliString("XX"),
     }}
 
 
 def test_detecting_region_filters():
-    c = stim.Circuit.generated("repetition_code:memory", distance=3, rounds=3)
+    c = lestim.Circuit.generated("repetition_code:memory", distance=3, rounds=3)
     assert len(c.detecting_regions(targets=["D"])) == c.num_detectors
     assert len(c.detecting_regions(targets=["L"])) == c.num_observables
     assert len(c.detecting_regions()) == c.num_observables + c.num_detectors
     assert len(c.detecting_regions(targets=["D0"])) == 1
     assert len(c.detecting_regions(targets=["D0", "L0"])) == 2
-    assert len(c.detecting_regions(targets=[stim.target_relative_detector_id(0), "D0"])) == 1
+    assert len(c.detecting_regions(targets=[lestim.target_relative_detector_id(0), "D0"])) == 1
 
 
 def test_detecting_regions_mzz():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         TICK
         MZZ 0 1 1 2
         TICK
@@ -1801,50 +1801,50 @@ def test_detecting_regions_mzz():
         DETECTOR rec[-1]
     """)
     assert c.detecting_regions() == {
-        stim.target_relative_detector_id(0): {
-            0: stim.PauliString("__Z"),
-            1: stim.PauliString("__Z"),
+        lestim.target_relative_detector_id(0): {
+            0: lestim.PauliString("__Z"),
+            1: lestim.PauliString("__Z"),
         },
     }
 
 
 def test_insert():
-    c = stim.Circuit()
+    c = lestim.Circuit()
     with pytest.raises(ValueError, match='type'):
         c.insert(0, object())
     with pytest.raises(ValueError, match='index <'):
-        c.insert(1, stim.CircuitInstruction("H", [1]))
+        c.insert(1, lestim.CircuitInstruction("H", [1]))
     with pytest.raises(ValueError, match='index <'):
-        c.insert(-1, stim.CircuitInstruction("H", [1]))
-    c.insert(0, stim.CircuitInstruction("H", [1]))
-    assert c == stim.Circuit("""
+        c.insert(-1, lestim.CircuitInstruction("H", [1]))
+    c.insert(0, lestim.CircuitInstruction("H", [1]))
+    assert c == lestim.Circuit("""
         H 1
     """)
 
     with pytest.raises(ValueError, match='index <'):
-        c.insert(2, stim.CircuitInstruction("S", [2]))
+        c.insert(2, lestim.CircuitInstruction("S", [2]))
     with pytest.raises(ValueError, match='index <'):
-        c.insert(-2, stim.CircuitInstruction("S", [2]))
-    c.insert(0, stim.CircuitInstruction("S", [2, 3]))
-    assert c == stim.Circuit("""
+        c.insert(-2, lestim.CircuitInstruction("S", [2]))
+    c.insert(0, lestim.CircuitInstruction("S", [2, 3]))
+    assert c == lestim.Circuit("""
         S 2 3
         H 1
     """)
 
-    c.insert(-1, stim.Circuit("H 5\nM 2"))
-    assert c == stim.Circuit("""
+    c.insert(-1, lestim.Circuit("H 5\nM 2"))
+    assert c == lestim.Circuit("""
         S 2 3
         H 5
         M 2
         H 1
     """)
 
-    c.insert(2, stim.Circuit("""
+    c.insert(2, lestim.Circuit("""
         REPEAT 100 {
             M 3
         }
     """))
-    assert c == stim.Circuit("""
+    assert c == lestim.Circuit("""
         S 2 3
         H 5
         REPEAT 100 {
@@ -1854,12 +1854,12 @@ def test_insert():
         H 1
     """)
 
-    c.insert(2, stim.Circuit("""
+    c.insert(2, lestim.Circuit("""
         REPEAT 100 {
             M 3
         }
     """)[0])
-    assert c == stim.Circuit("""
+    assert c == lestim.Circuit("""
         S 2 3
         H 5
         REPEAT 100 {
@@ -1875,116 +1875,116 @@ def test_insert():
 
 def test_pop():
     with pytest.raises(IndexError, match='index'):
-        stim.Circuit().pop()
+        lestim.Circuit().pop()
     with pytest.raises(IndexError, match='index'):
-        stim.Circuit().pop(-1)
+        lestim.Circuit().pop(-1)
     with pytest.raises(IndexError, match='index'):
-        stim.Circuit().pop(0)
-    c = stim.Circuit("H 0")
+        lestim.Circuit().pop(0)
+    c = lestim.Circuit("H 0")
     with pytest.raises(IndexError, match='index'):
         c.pop(1)
     with pytest.raises(IndexError, match='index'):
         c.pop(-2)
-    assert c.pop(0) == stim.CircuitInstruction("H", [0])
-    c = stim.Circuit("H 0\n X 1")
-    assert c.pop() == stim.CircuitInstruction("X", [1])
-    assert c.pop() == stim.CircuitInstruction("H", [0])
+    assert c.pop(0) == lestim.CircuitInstruction("H", [0])
+    c = lestim.Circuit("H 0\n X 1")
+    assert c.pop() == lestim.CircuitInstruction("X", [1])
+    assert c.pop() == lestim.CircuitInstruction("H", [0])
 
 
 def test_circuit_create_with_odd_cx():
     with pytest.raises(ValueError, match="0, 1, 2"):
-        stim.Circuit("CX 0 1 2")
+        lestim.Circuit("CX 0 1 2")
 
 
 def test_to_tableau():
-    assert stim.Circuit().to_tableau() == stim.Tableau(0)
-    assert stim.Circuit("QUBIT_COORDS 0").to_tableau() == stim.Tableau(1)
-    assert stim.Circuit("I 0").to_tableau() == stim.Tableau(1)
-    assert stim.Circuit("H 0").to_tableau() == stim.Tableau.from_named_gate("H")
-    assert stim.Circuit("CX 0 1").to_tableau() == stim.Tableau.from_named_gate("CX")
-    assert stim.Circuit("SPP Z0").to_tableau() == stim.Tableau.from_named_gate("S")
-    assert stim.Circuit("SPP X0").to_tableau() == stim.Tableau.from_named_gate("SQRT_X")
-    assert stim.Circuit("SPP_DAG Y0*Y1").to_tableau() == stim.Tableau.from_named_gate("SQRT_YY_DAG")
+    assert lestim.Circuit().to_tableau() == lestim.Tableau(0)
+    assert lestim.Circuit("QUBIT_COORDS 0").to_tableau() == lestim.Tableau(1)
+    assert lestim.Circuit("I 0").to_tableau() == lestim.Tableau(1)
+    assert lestim.Circuit("H 0").to_tableau() == lestim.Tableau.from_named_gate("H")
+    assert lestim.Circuit("CX 0 1").to_tableau() == lestim.Tableau.from_named_gate("CX")
+    assert lestim.Circuit("SPP Z0").to_tableau() == lestim.Tableau.from_named_gate("S")
+    assert lestim.Circuit("SPP X0").to_tableau() == lestim.Tableau.from_named_gate("SQRT_X")
+    assert lestim.Circuit("SPP_DAG Y0*Y1").to_tableau() == lestim.Tableau.from_named_gate("SQRT_YY_DAG")
 
 
 def test_circuit_tags():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         H[test] 0
     """)
     assert str(c) == "H[test] 0"
     assert c[0].tag == 'test'
-    c.append(stim.CircuitInstruction('CX', [0, 1], tag='test2'))
+    c.append(lestim.CircuitInstruction('CX', [0, 1], tag='test2'))
     assert c[1].tag == 'test2'
-    assert c == stim.Circuit("""
+    assert c == lestim.Circuit("""
         H[test] 0
         CX[test2] 0 1
     """)
-    assert c != stim.Circuit("""
+    assert c != lestim.Circuit("""
         H 0
         CX 0 1
     """)
 
 
 def test_circuit_add_tags():
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         H[test] 0
-    """) + stim.Circuit("""
+    """) + lestim.Circuit("""
         CX[test2] 0 1
-    """) == stim.Circuit("""
+    """) == lestim.Circuit("""
         H[test] 0
         CX[test2] 0 1
     """)
 
 
 def test_circuit_eq_tags():
-    assert stim.CircuitInstruction("TICK", tag="a") == stim.CircuitInstruction("TICK", tag="a")
-    assert stim.CircuitInstruction("TICK", tag="a") != stim.CircuitInstruction("TICK", tag="b")
-    assert stim.CircuitRepeatBlock(1, stim.Circuit(), tag="a") == stim.CircuitRepeatBlock(1, stim.Circuit(), tag="a")
-    assert stim.CircuitRepeatBlock(1, stim.Circuit(), tag="a") != stim.CircuitRepeatBlock(1, stim.Circuit(), tag="b")
-    assert stim.Circuit("""
+    assert lestim.CircuitInstruction("TICK", tag="a") == lestim.CircuitInstruction("TICK", tag="a")
+    assert lestim.CircuitInstruction("TICK", tag="a") != lestim.CircuitInstruction("TICK", tag="b")
+    assert lestim.CircuitRepeatBlock(1, lestim.Circuit(), tag="a") == lestim.CircuitRepeatBlock(1, lestim.Circuit(), tag="a")
+    assert lestim.CircuitRepeatBlock(1, lestim.Circuit(), tag="a") != lestim.CircuitRepeatBlock(1, lestim.Circuit(), tag="b")
+    assert lestim.Circuit("""
         H[test] 0
-    """) == stim.Circuit("""
+    """) == lestim.Circuit("""
         H[test] 0
     """)
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         H[test] 0
-    """) != stim.Circuit("""
+    """) != lestim.Circuit("""
         H[test2] 0
     """)
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         H[test] 0
-    """) != stim.Circuit("""
+    """) != lestim.Circuit("""
         H 0
     """)
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         H[] 0
-    """) == stim.Circuit("""
+    """) == lestim.Circuit("""
         H 0
     """)
 
 
 def test_circuit_get_item_tags():
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         H[test] 0
         CX[test2] 1 2
         REPEAT[test3] 3 {
             M[test4](0.25) 4
         }
-    """)[1] == stim.CircuitInstruction("CX[test2] 1 2")
-    assert stim.Circuit("""
+    """)[1] == lestim.CircuitInstruction("CX[test2] 1 2")
+    assert lestim.Circuit("""
         H[test] 0
         CX[test2] 1 2
         REPEAT[test3] 3 {
             M[test4](0.25) 4
         }
-    """)[2] == stim.CircuitRepeatBlock(3, stim.Circuit("M[test4](0.25) 4"), tag="test3")
-    assert stim.Circuit("""
+    """)[2] == lestim.CircuitRepeatBlock(3, lestim.Circuit("M[test4](0.25) 4"), tag="test3")
+    assert lestim.Circuit("""
         H[test] 0
         CX[test2] 1 2
         REPEAT[test3] 3 {
             M[test4](0.25) 4
         }
-    """)[1:3] == stim.Circuit("""
+    """)[1:3] == lestim.Circuit("""
         CX[test2] 1 2
         REPEAT[test3] 3 {
             M[test4](0.25) 4
@@ -1993,16 +1993,16 @@ def test_circuit_get_item_tags():
 
 
 def test_tags_iadd():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         H[test] 0
         CX[test2] 1 2
     """)
-    c += stim.Circuit("""
+    c += lestim.Circuit("""
         REPEAT[test3] 3 {
             M[test4](0.25) 4
         }
     """)
-    assert c == stim.Circuit("""
+    assert c == lestim.Circuit("""
         H[test] 0
         CX[test2] 1 2
         REPEAT[test3] 3 {
@@ -2012,12 +2012,12 @@ def test_tags_iadd():
 
 
 def test_tags_imul():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         H[test] 0
         CX[test2] 1 2
     """)
     c *= 2
-    assert c == stim.Circuit("""
+    assert c == lestim.Circuit("""
         REPEAT 2 {
             H[test] 0
             CX[test2] 1 2
@@ -2026,11 +2026,11 @@ def test_tags_imul():
 
 
 def test_tags_mul():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         H[test] 0
         CX[test2] 1 2
     """)
-    assert c * 2 == stim.Circuit("""
+    assert c * 2 == lestim.Circuit("""
         REPEAT 2 {
             H[test] 0
             CX[test2] 1 2
@@ -2039,14 +2039,14 @@ def test_tags_mul():
 
 
 def test_tags_append():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         H[test] 0
         CX[test2] 1 2
     """)
-    c.append(stim.CircuitRepeatBlock(3, stim.Circuit("""
+    c.append(lestim.CircuitRepeatBlock(3, lestim.Circuit("""
         M[test4](0.25) 4
     """), tag="test3"))
-    assert c == stim.Circuit("""
+    assert c == lestim.Circuit("""
         H[test] 0
         CX[test2] 1 2
         REPEAT[test3] 3 {
@@ -2056,30 +2056,30 @@ def test_tags_append():
 
 
 def test_tags_append_from_stim_program_text():
-    c = stim.Circuit()
+    c = lestim.Circuit()
     c.append_from_stim_program_text("""
         H[test] 0
         CX[test2] 1 2
     """)
-    assert c == stim.Circuit("""
+    assert c == lestim.Circuit("""
         H[test] 0
         CX[test2] 1 2
     """)
 
 
 def test_tag_approx_equals():
-    assert not stim.Circuit("H[test] 0").approx_equals(stim.Circuit("H[test2] 0"), atol=3)
-    assert stim.Circuit("H[test] 0").approx_equals(stim.Circuit("H[test] 0"), atol=3)
+    assert not lestim.Circuit("H[test] 0").approx_equals(lestim.Circuit("H[test2] 0"), atol=3)
+    assert lestim.Circuit("H[test] 0").approx_equals(lestim.Circuit("H[test] 0"), atol=3)
 
 
 def test_tag_clear():
-    c = stim.Circuit("H[test] 0")
+    c = lestim.Circuit("H[test] 0")
     c.clear()
-    assert c == stim.Circuit()
+    assert c == lestim.Circuit()
 
 
 def test_tag_compile_samplers():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         R[test1] 0
         X_ERROR[test2](0.25) 0
         M[test3](0.25) 0
@@ -2093,13 +2093,13 @@ def test_tag_compile_samplers():
 
 
 def test_tag_detector_error_model():
-    dem = stim.Circuit("""
+    dem = lestim.Circuit("""
         R[test1] 0
         X_ERROR[test2](0.25) 0
         M[test3](0.25) 0
         DETECTOR[test4](1, 2) rec[-1]
     """).detector_error_model()
-    assert dem == stim.DetectorErrorModel("""
+    assert dem == lestim.DetectorErrorModel("""
         error[test2](0.25) D0
         error[test3](0.25) D0
         detector[test4](1, 2) D0
@@ -2107,7 +2107,7 @@ def test_tag_detector_error_model():
 
 
 def test_tag_copy():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         H[test] 0
         CX[test2] 1 2
         REPEAT[test3] 3 {
@@ -2120,7 +2120,7 @@ def test_tag_copy():
 
 
 def test_tag_count_determined_measurements():
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         R[test1] 0
         X_ERROR[test2](0.25) 0
         M[test3](0.25) 0
@@ -2129,13 +2129,13 @@ def test_tag_count_determined_measurements():
 
 
 def test_tag_decomposed():
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         RX[test1] 0
         X_ERROR[test2](0.25) 0
         MPP[test3](0.25) X0*Z1
         DETECTOR[test4](1, 2) rec[-1]
         SPP[test5] Y0
-    """).decomposed() == stim.Circuit("""
+    """).decomposed() == lestim.Circuit("""
         R[test1] 0
         H[test1] 0
         X_ERROR[test2](0.25) 0
@@ -2157,18 +2157,18 @@ def test_tag_decomposed():
 
 
 def test_tag_detecting_regions():
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         R[test1] 0
         X_ERROR[test2](0.25) 0
         TICK
         M[test3](0.25) 0
         DETECTOR[test4](1, 2) rec[-1]
-    """).detecting_regions() == {stim.DemTarget('D0'): {0: stim.PauliString("Z")}}
+    """).detecting_regions() == {lestim.DemTarget('D0'): {0: lestim.PauliString("Z")}}
 
 
 def test_tag_diagram():
     # TODO: include tags in diagrams
-    assert str(stim.Circuit("""
+    assert str(lestim.Circuit("""
         R[test1] 0
         X_ERROR[test2](0.25) 0
         M[test3](0.25) 0
@@ -2179,12 +2179,12 @@ def test_tag_diagram():
 
 
 def test_tag_flattened():
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         R[test1] 0
         REPEAT[test1.5] 2 {
             H[test2] 0
         }
-    """).flattened() == stim.Circuit("""
+    """).flattened() == lestim.Circuit("""
         R[test1] 0
         H[test2] 0
         H[test2] 0
@@ -2192,13 +2192,13 @@ def test_tag_flattened():
 
 
 def test_tag_from_file():
-    c = stim.Circuit.from_file(io.StringIO("""
+    c = lestim.Circuit.from_file(io.StringIO("""
         R[test1] 0
         REPEAT[test1.5] 2 {
             H[test2] 0
         }
     """))
-    assert c == stim.Circuit("""
+    assert c == lestim.Circuit("""
         R[test1] 0
         REPEAT[test1.5] 2 {
             H[test2] 0
@@ -2211,12 +2211,12 @@ def test_tag_from_file():
 
 
 def test_tag_insert():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         H[test1] 0
         S[test2] 0
     """)
-    c.insert(1, stim.CircuitInstruction("CX[test3] 0 1"))
-    assert c == stim.Circuit("""
+    c.insert(1, lestim.CircuitInstruction("CX[test3] 0 1"))
+    assert c == lestim.Circuit("""
         H[test1] 0
         CX[test3] 0 1
         S[test2] 0
@@ -2224,7 +2224,7 @@ def test_tag_insert():
 
 
 def test_tag_fuse():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         H[test1] 0
         H[test1] 0
         H[test2] 0
@@ -2237,14 +2237,14 @@ def test_tag_fuse():
 
 
 def test_tag_inverse():
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         S[test1] 0
         CX[test2] 0 1
         SPP[test3] X0*Y1
         REPEAT[test4] 2 {
             H[test5] 0
         }
-    """).inverse() == stim.Circuit("""
+    """).inverse() == lestim.Circuit("""
         REPEAT[test4] 2 {
             H[test5] 0
         }
@@ -2255,14 +2255,14 @@ def test_tag_inverse():
 
 
 def test_tag_time_reversed_for_flows():
-    c, _ = stim.Circuit("""
+    c, _ = lestim.Circuit("""
         R[test1] 0
         X_ERROR[test2](0.25) 0
         SQRT_X[test3] 0
         MY[test4] 0
         DETECTOR[test5] rec[-1]
     """).time_reversed_for_flows([])
-    assert c == stim.Circuit("""
+    assert c == lestim.Circuit("""
         RY[test4] 0
         SQRT_X_DAG[test3] 0
         X_ERROR[test2](0.25) 0
@@ -2272,14 +2272,14 @@ def test_tag_time_reversed_for_flows():
 
 
 def test_tag_with_inlined_feedback():
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         R[test1] 0
         X_ERROR[test2](0.25) 0 1
         MR[test3] 0
         CX[test4] rec[-1] 1
         M[test5] 1
         DETECTOR[test6] rec[-1]
-    """).with_inlined_feedback() == stim.Circuit("""
+    """).with_inlined_feedback() == lestim.Circuit("""
         R[test1] 0
         X_ERROR[test2](0.25) 0 1
         MR[test3] 0
@@ -2289,12 +2289,12 @@ def test_tag_with_inlined_feedback():
 
 
 def test_tag_without_noise():
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         R[test1] 0
         X_ERROR[test2](0.25) 0 1
         M[test3](0.25) 0
         DETECTOR[test4] rec[-1]
-    """).without_noise() == stim.Circuit("""
+    """).without_noise() == lestim.Circuit("""
         R[test1] 0
         M[test3] 0
         DETECTOR[test4] rec[-1]
@@ -2302,41 +2302,41 @@ def test_tag_without_noise():
 
 
 def test_append_tag():
-    c = stim.Circuit()
+    c = lestim.Circuit()
     c.append("H", [2, 3], tag="test")
-    assert c == stim.Circuit("H[test] 2 3")
+    assert c == lestim.Circuit("H[test] 2 3")
 
     with pytest.raises(ValueError, match="tag"):
         c.append(c[0], tag="newtag")
 
     with pytest.raises(ValueError, match="tag"):
-        c.append(stim.CircuitRepeatBlock(10, stim.Circuit()), tag="newtag")
+        c.append(lestim.CircuitRepeatBlock(10, lestim.Circuit()), tag="newtag")
 
-    assert c == stim.Circuit("H[test] 2 3")
+    assert c == lestim.Circuit("H[test] 2 3")
 
 
 def test_append_pauli_string():
-    c = stim.Circuit()
+    c = lestim.Circuit()
     c.append("MPP", [
-        stim.PauliString("X1*Y2*Z3"),
-        stim.target_y(4),
-        stim.PauliString("Z5"),
+        lestim.PauliString("X1*Y2*Z3"),
+        lestim.target_y(4),
+        lestim.PauliString("Z5"),
     ])
-    assert c == stim.Circuit("""
+    assert c == lestim.Circuit("""
         MPP X1*Y2*Z3 Y4 Z5
     """)
-    c.append("MPP", stim.PauliString("X1*X2"))
-    assert c == stim.Circuit("""
+    c.append("MPP", lestim.PauliString("X1*X2"))
+    assert c == lestim.Circuit("""
         MPP X1*Y2*Z3 Y4 Z5 X1*X2
     """)
 
     with pytest.raises(ValueError, match="empty stim.PauliString"):
-        c.append("MPP", stim.PauliString(""))
+        c.append("MPP", lestim.PauliString(""))
     with pytest.raises(ValueError, match="empty stim.PauliString"):
-        c.append("MPP", [stim.PauliString("")])
+        c.append("MPP", [lestim.PauliString("")])
     with pytest.raises(ValueError, match="empty stim.PauliString"):
-        c.append("MPP", [stim.PauliString("X1"), stim.PauliString("")])
-    assert c == stim.Circuit("""
+        c.append("MPP", [lestim.PauliString("X1"), lestim.PauliString("")])
+    assert c == lestim.Circuit("""
         MPP X1*Y2*Z3 Y4 Z5 X1*X2
     """)
 
@@ -2347,16 +2347,16 @@ def test_append_pauli_string():
 
 
 def test_without_tags():
-    circuit = stim.Circuit("""
+    circuit = lestim.Circuit("""
         H[tag] 5
     """)
-    assert circuit.without_tags() == stim.Circuit("""
+    assert circuit.without_tags() == lestim.Circuit("""
         H 5
     """)
 
 
 def test_reference_detector_and_observable_signs():
-    det, obs = stim.Circuit("""
+    det, obs = lestim.Circuit("""
         X 1
         M 0 1
         DETECTOR rec[-1]
@@ -2368,7 +2368,7 @@ def test_reference_detector_and_observable_signs():
     np.testing.assert_array_equal(det, [True, False])
     np.testing.assert_array_equal(obs, [False, False, False, True])
 
-    det, obs = stim.Circuit("""
+    det, obs = lestim.Circuit("""
         X 1
         M 0 1
         DETECTOR rec[-1]
@@ -2380,7 +2380,7 @@ def test_reference_detector_and_observable_signs():
     np.testing.assert_array_equal(det, [0b01])
     np.testing.assert_array_equal(obs, [0b1000])
 
-    circuit = stim.Circuit.generated("surface_code:rotated_memory_x", rounds=3, distance=3)
+    circuit = lestim.Circuit.generated("surface_code:rotated_memory_x", rounds=3, distance=3)
     det, obs = circuit.reference_detector_and_observable_signs(bit_packed=True)
     assert det.dtype == np.uint8
     assert obs.dtype == np.uint8
@@ -2391,26 +2391,26 @@ def test_reference_detector_and_observable_signs():
 
 
 def test_without_noise_removes_id_errors():
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         I_ERROR 0
         I_ERROR(0.25) 1
         II_ERROR 2 3
         II_ERROR(0.125) 3 4
         H 0
-    """).without_noise() == stim.Circuit("""
+    """).without_noise() == lestim.Circuit("""
         H 0
     """)
 
 
 def test_append_circuit_to_circuit():
-    circuit = stim.Circuit("""
+    circuit = lestim.Circuit("""
         H 0
     """)
-    circuit.append(stim.Circuit("""
+    circuit.append(lestim.Circuit("""
         X 1
         Z 2
     """))
-    assert circuit == stim.Circuit("""
+    assert circuit == lestim.Circuit("""
         H 0
         X 1
         Z 2

--- a/src/stim/circuit/circuit_repeat_block_test.py
+++ b/src/stim/circuit/circuit_repeat_block_test.py
@@ -12,37 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import stim
+import lestim
 import pytest
 
 
 def test_init_and_equality():
-    r = stim.CircuitRepeatBlock(500, stim.Circuit("X 0"))
+    r = lestim.CircuitRepeatBlock(500, lestim.Circuit("X 0"))
     assert r.repeat_count == 500
-    assert r.body_copy() == stim.Circuit("X 0")
-    assert stim.CircuitRepeatBlock(500, stim.Circuit("X 0")) == stim.CircuitRepeatBlock(500, stim.Circuit("X 0"))
-    assert stim.CircuitRepeatBlock(500, stim.Circuit("X 0")) != stim.CircuitRepeatBlock(500, stim.Circuit())
-    assert stim.CircuitRepeatBlock(500, stim.Circuit("X 0")) != stim.CircuitRepeatBlock(101, stim.Circuit("X 0"))
-    assert not (stim.CircuitRepeatBlock(500, stim.Circuit("X 0")) == stim.CircuitRepeatBlock(500, stim.Circuit()))
-    assert not (stim.CircuitRepeatBlock(500, stim.Circuit("X 0")) != stim.CircuitRepeatBlock(500, stim.Circuit("X 0")))
-    r2 = stim.CircuitRepeatBlock(repeat_count=500, body=stim.Circuit("X 0"))
+    assert r.body_copy() == lestim.Circuit("X 0")
+    assert lestim.CircuitRepeatBlock(500, lestim.Circuit("X 0")) == lestim.CircuitRepeatBlock(500, lestim.Circuit("X 0"))
+    assert lestim.CircuitRepeatBlock(500, lestim.Circuit("X 0")) != lestim.CircuitRepeatBlock(500, lestim.Circuit())
+    assert lestim.CircuitRepeatBlock(500, lestim.Circuit("X 0")) != lestim.CircuitRepeatBlock(101, lestim.Circuit("X 0"))
+    assert not (lestim.CircuitRepeatBlock(500, lestim.Circuit("X 0")) == lestim.CircuitRepeatBlock(500, lestim.Circuit()))
+    assert not (lestim.CircuitRepeatBlock(500, lestim.Circuit("X 0")) != lestim.CircuitRepeatBlock(500, lestim.Circuit("X 0")))
+    r2 = lestim.CircuitRepeatBlock(repeat_count=500, body=lestim.Circuit("X 0"))
     assert r == r2
 
     with pytest.raises(ValueError, match="repeat 0"):
-        stim.CircuitRepeatBlock(0, stim.Circuit())
+        lestim.CircuitRepeatBlock(0, lestim.Circuit())
 
 
 @pytest.mark.parametrize("value", [
-    stim.CircuitRepeatBlock(500, stim.Circuit("X 0")),
-    stim.CircuitRepeatBlock(1, stim.Circuit("X 0\nREPEAT 100 {\nH 1\n}\n")),
+    lestim.CircuitRepeatBlock(500, lestim.Circuit("X 0")),
+    lestim.CircuitRepeatBlock(1, lestim.Circuit("X 0\nREPEAT 100 {\nH 1\n}\n")),
 ])
 def test_repr(value):
-    assert eval(repr(value), {'stim': stim}) == value
-    assert repr(eval(repr(value), {'stim': stim})) == repr(value)
+    assert eval(repr(value), {'stim': lestim}) == value
+    assert repr(eval(repr(value), {'stim': lestim})) == repr(value)
 
 
 def test_name():
-    assert [e.name for e in stim.Circuit('''
+    assert [e.name for e in lestim.Circuit('''
         H 0
         REPEAT 5 {
             CX 1 2

--- a/src/stim/circuit/gate_target_pybind_test.py
+++ b/src/stim/circuit/gate_target_pybind_test.py
@@ -12,22 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import stim
+import lestim
 import pytest
 
 
 def test_init_and_equality():
-    assert stim.GateTarget(5) == stim.GateTarget(5)
-    assert stim.GateTarget(5) == stim.GateTarget(value=5)
-    assert not (stim.GateTarget(4) == stim.GateTarget(5))
-    assert stim.GateTarget(4) != stim.GateTarget(5)
-    assert not (stim.GateTarget(5) != stim.GateTarget(5))
-    assert stim.GateTarget(stim.target_x(5)) != stim.GateTarget(5)
-    assert stim.GateTarget(5) == stim.GateTarget(stim.GateTarget(5))
+    assert lestim.GateTarget(5) == lestim.GateTarget(5)
+    assert lestim.GateTarget(5) == lestim.GateTarget(value=5)
+    assert not (lestim.GateTarget(4) == lestim.GateTarget(5))
+    assert lestim.GateTarget(4) != lestim.GateTarget(5)
+    assert not (lestim.GateTarget(5) != lestim.GateTarget(5))
+    assert lestim.GateTarget(lestim.target_x(5)) != lestim.GateTarget(5)
+    assert lestim.GateTarget(5) == lestim.GateTarget(lestim.GateTarget(5))
 
 
 def test_properties():
-    g = stim.GateTarget(5)
+    g = lestim.GateTarget(5)
     assert g.value == 5
     assert not g.is_x_target
     assert not g.is_y_target
@@ -37,7 +37,7 @@ def test_properties():
     assert not g.is_combiner
     assert g.is_qubit_target
 
-    g = stim.GateTarget(stim.target_rec(-4))
+    g = lestim.GateTarget(lestim.target_rec(-4))
     assert g.value == -4
     assert not g.is_x_target
     assert not g.is_y_target
@@ -47,7 +47,7 @@ def test_properties():
     assert not g.is_combiner
     assert not g.is_qubit_target
 
-    g = stim.GateTarget(stim.target_x(3))
+    g = lestim.GateTarget(lestim.target_x(3))
     assert g.value == 3
     assert g.is_x_target
     assert not g.is_y_target
@@ -57,7 +57,7 @@ def test_properties():
     assert not g.is_combiner
     assert not g.is_qubit_target
 
-    g = stim.GateTarget(stim.target_y(3))
+    g = lestim.GateTarget(lestim.target_y(3))
     assert g.value == 3
     assert not g.is_x_target
     assert g.is_y_target
@@ -67,7 +67,7 @@ def test_properties():
     assert not g.is_combiner
     assert not g.is_qubit_target
 
-    g = stim.GateTarget(stim.target_z(3))
+    g = lestim.GateTarget(lestim.target_z(3))
     assert g.value == 3
     assert not g.is_x_target
     assert not g.is_y_target
@@ -77,7 +77,7 @@ def test_properties():
     assert not g.is_combiner
     assert not g.is_qubit_target
 
-    g = stim.GateTarget(stim.target_z(3, invert=True))
+    g = lestim.GateTarget(lestim.target_z(3, invert=True))
     assert g.value == 3
     assert not g.is_x_target
     assert not g.is_y_target
@@ -87,7 +87,7 @@ def test_properties():
     assert not g.is_combiner
     assert not g.is_qubit_target
 
-    g = stim.GateTarget(stim.target_inv(3))
+    g = lestim.GateTarget(lestim.target_inv(3))
     assert g.value == 3
     assert not g.is_x_target
     assert not g.is_y_target
@@ -97,7 +97,7 @@ def test_properties():
     assert not g.is_combiner
     assert g.is_qubit_target
 
-    g = stim.target_combiner()
+    g = lestim.target_combiner()
     assert not g.is_x_target
     assert not g.is_y_target
     assert not g.is_z_target
@@ -108,33 +108,33 @@ def test_properties():
 
 
 @pytest.mark.parametrize("value", [
-    stim.GateTarget(5),
-    stim.GateTarget(stim.target_rec(-5)),
-    stim.GateTarget(stim.target_x(5)),
-    stim.GateTarget(stim.target_y(5)),
-    stim.GateTarget(stim.target_z(5)),
-    stim.GateTarget(stim.target_inv(5)),
+    lestim.GateTarget(5),
+    lestim.GateTarget(lestim.target_rec(-5)),
+    lestim.GateTarget(lestim.target_x(5)),
+    lestim.GateTarget(lestim.target_y(5)),
+    lestim.GateTarget(lestim.target_z(5)),
+    lestim.GateTarget(lestim.target_inv(5)),
 ])
 def test_repr(value):
-    assert eval(repr(value), {'stim': stim}) == value
-    assert repr(eval(repr(value), {'stim': stim})) == repr(value)
+    assert eval(repr(value), {'stim': lestim}) == value
+    assert repr(eval(repr(value), {'stim': lestim})) == repr(value)
 
 
 def test_hashable():
-    a = stim.GateTarget(5)
-    b = stim.GateTarget(6)
-    c = stim.GateTarget(5)
+    a = lestim.GateTarget(5)
+    b = lestim.GateTarget(6)
+    c = lestim.GateTarget(5)
     assert hash(a) == hash(c)
     assert len({a, b, c}) == 2
 
 
 def test_pauli_type():
-    assert stim.GateTarget(5).pauli_type == 'I'
-    assert stim.target_inv(5).pauli_type == 'I'
-    assert stim.target_rec(-5).pauli_type == 'I'
-    assert stim.target_sweep_bit(6).pauli_type == 'I'
+    assert lestim.GateTarget(5).pauli_type == 'I'
+    assert lestim.target_inv(5).pauli_type == 'I'
+    assert lestim.target_rec(-5).pauli_type == 'I'
+    assert lestim.target_sweep_bit(6).pauli_type == 'I'
 
-    assert stim.target_x(7).pauli_type == 'X'
-    assert stim.target_y(8).pauli_type == 'Y'
-    assert stim.target_y(8, invert=True).pauli_type == 'Y'
-    assert stim.target_z(9).pauli_type == 'Z'
+    assert lestim.target_x(7).pauli_type == 'X'
+    assert lestim.target_y(8).pauli_type == 'Y'
+    assert lestim.target_y(8, invert=True).pauli_type == 'Y'
+    assert lestim.target_z(9).pauli_type == 'Z'

--- a/src/stim/dem/dem_instruction.pybind.cc
+++ b/src/stim/dem/dem_instruction.pybind.cc
@@ -107,6 +107,7 @@ pybind11::class_<ExposedDemInstruction> stim_pybind::pybind_detector_error_model
     return pybind11::class_<ExposedDemInstruction>(
         m,
         "DemInstruction",
+        pybind11::module_local(),
         clean_doc_string(R"DOC(
             An instruction from a detector error model.
 

--- a/src/stim/dem/dem_instruction_pybind_test.py
+++ b/src/stim/dem/dem_instruction_pybind_test.py
@@ -1,93 +1,93 @@
-import stim
+import lestim
 import pytest
 
 
 def test_args_copy():
-    assert stim.DemInstruction("error", [0.25], [stim.target_relative_detector_id(3)]).args_copy() == [0.25]
-    assert stim.DemInstruction("error", [0.125], [stim.target_relative_detector_id(3)]).args_copy() == [0.125]
-    assert stim.DemInstruction("shift_detectors", [], [1]).args_copy() == []
-    assert stim.DemInstruction("shift_detectors", [0.125, 0.25], [1]).args_copy() == [0.125, 0.25]
+    assert lestim.DemInstruction("error", [0.25], [lestim.target_relative_detector_id(3)]).args_copy() == [0.25]
+    assert lestim.DemInstruction("error", [0.125], [lestim.target_relative_detector_id(3)]).args_copy() == [0.125]
+    assert lestim.DemInstruction("shift_detectors", [], [1]).args_copy() == []
+    assert lestim.DemInstruction("shift_detectors", [0.125, 0.25], [1]).args_copy() == [0.125, 0.25]
 
 
 def test_targets_copy():
-    t1 = [stim.target_relative_detector_id(3), stim.target_separator(), stim.target_logical_observable_id(2)]
-    assert stim.DemInstruction("error", [0.25], t1).targets_copy() == t1
-    assert stim.DemInstruction("shift_detectors", [], [1]).targets_copy() == [1]
-    t2 = [stim.target_logical_observable_id(3)]
-    assert stim.DemInstruction("logical_observable", [], t2).targets_copy() == t2
+    t1 = [lestim.target_relative_detector_id(3), lestim.target_separator(), lestim.target_logical_observable_id(2)]
+    assert lestim.DemInstruction("error", [0.25], t1).targets_copy() == t1
+    assert lestim.DemInstruction("shift_detectors", [], [1]).targets_copy() == [1]
+    t2 = [lestim.target_logical_observable_id(3)]
+    assert lestim.DemInstruction("logical_observable", [], t2).targets_copy() == t2
 
 
 def test_type():
-    assert stim.DemInstruction("error", [0.25], [stim.target_relative_detector_id(3)]).type == "error"
-    assert stim.DemInstruction("ERROR", [0.25], [stim.target_relative_detector_id(3)]).type == "error"
-    assert stim.DemInstruction("shift_detectors", [], [1]).type == "shift_detectors"
-    assert stim.DemInstruction("detector", [], [stim.target_relative_detector_id(3)]).type == "detector"
-    assert stim.DemInstruction("logical_observable", [], [stim.target_logical_observable_id(3)]).type == "logical_observable"
+    assert lestim.DemInstruction("error", [0.25], [lestim.target_relative_detector_id(3)]).type == "error"
+    assert lestim.DemInstruction("ERROR", [0.25], [lestim.target_relative_detector_id(3)]).type == "error"
+    assert lestim.DemInstruction("shift_detectors", [], [1]).type == "shift_detectors"
+    assert lestim.DemInstruction("detector", [], [lestim.target_relative_detector_id(3)]).type == "detector"
+    assert lestim.DemInstruction("logical_observable", [], [lestim.target_logical_observable_id(3)]).type == "logical_observable"
 
 
 def test_equality():
-    e1 = stim.DemInstruction("error", [0.25], [stim.target_relative_detector_id(3)])
-    assert e1 == stim.DemInstruction("error", [0.25], [stim.target_relative_detector_id(3)])
-    assert not (e1 != stim.DemInstruction("error", [0.25], [stim.target_relative_detector_id(3)]))
-    assert e1 != stim.DemInstruction("error", [0.35], [stim.target_relative_detector_id(3)])
-    assert not (e1 == stim.DemInstruction("error", [0.35], [stim.target_relative_detector_id(3)]))
-    assert e1 != stim.DemInstruction("error", [0.35], [stim.target_relative_detector_id(4)])
-    assert e1 != stim.DemInstruction("shift_detectors", [0.35], [3])
+    e1 = lestim.DemInstruction("error", [0.25], [lestim.target_relative_detector_id(3)])
+    assert e1 == lestim.DemInstruction("error", [0.25], [lestim.target_relative_detector_id(3)])
+    assert not (e1 != lestim.DemInstruction("error", [0.25], [lestim.target_relative_detector_id(3)]))
+    assert e1 != lestim.DemInstruction("error", [0.35], [lestim.target_relative_detector_id(3)])
+    assert not (e1 == lestim.DemInstruction("error", [0.35], [lestim.target_relative_detector_id(3)]))
+    assert e1 != lestim.DemInstruction("error", [0.35], [lestim.target_relative_detector_id(4)])
+    assert e1 != lestim.DemInstruction("shift_detectors", [0.35], [3])
 
 
 def test_validation():
     with pytest.raises(ValueError, match="takes 1 arg"):
-        stim.DemInstruction("error", [], [stim.target_relative_detector_id(3)])
+        lestim.DemInstruction("error", [], [lestim.target_relative_detector_id(3)])
     with pytest.raises(ValueError, match="takes 1 arg"):
-        stim.DemInstruction("error", [0.5, 0.5], [stim.target_relative_detector_id(3)])
+        lestim.DemInstruction("error", [0.5, 0.5], [lestim.target_relative_detector_id(3)])
     with pytest.raises(ValueError, match="last target.+separator"):
-        stim.DemInstruction("error", [0.25], [stim.target_separator()])
+        lestim.DemInstruction("error", [0.25], [lestim.target_separator()])
     with pytest.raises(ValueError, match="0 to 1"):
-        stim.DemInstruction("error", [-0.1], [stim.target_relative_detector_id(3)])
+        lestim.DemInstruction("error", [-0.1], [lestim.target_relative_detector_id(3)])
     with pytest.raises(ValueError, match="0 to 1"):
-        stim.DemInstruction("error", [1.1], [stim.target_relative_detector_id(3)])
+        lestim.DemInstruction("error", [1.1], [lestim.target_relative_detector_id(3)])
     with pytest.raises(ValueError, match="detector.+targets"):
-        stim.DemInstruction("error", [0.25], [3])
+        lestim.DemInstruction("error", [0.25], [3])
 
     with pytest.raises(ValueError, match="integer targets"):
-        stim.DemInstruction("shift_detectors", [1.1], [stim.target_relative_detector_id(3)])
+        lestim.DemInstruction("shift_detectors", [1.1], [lestim.target_relative_detector_id(3)])
 
 
 def test_str():
-    v = stim.DemInstruction("ERROR", [0.125], [stim.target_relative_detector_id(3), stim.target_logical_observable_id(6)])
+    v = lestim.DemInstruction("ERROR", [0.125], [lestim.target_relative_detector_id(3), lestim.target_logical_observable_id(6)])
     assert str(v) == "error(0.125) D3 L6"
-    v = stim.DemInstruction("Shift_detectors", [1.5, 2.5, 5.5], [6])
+    v = lestim.DemInstruction("Shift_detectors", [1.5, 2.5, 5.5], [6])
     assert str(v) == "shift_detectors(1.5, 2.5, 5.5) 6"
 
 
 def test_repr():
-    v = stim.DemInstruction("error", [0.25], [stim.target_relative_detector_id(3), stim.target_logical_observable_id(6)])
-    assert eval(repr(v), {"stim": stim}) == v
-    v = stim.DemInstruction("shift_detectors", [1.5, 2.5, 5.5], [6])
-    assert eval(repr(v), {"stim": stim}) == v
+    v = lestim.DemInstruction("error", [0.25], [lestim.target_relative_detector_id(3), lestim.target_logical_observable_id(6)])
+    assert eval(repr(v), {"stim": lestim}) == v
+    v = lestim.DemInstruction("shift_detectors", [1.5, 2.5, 5.5], [6])
+    assert eval(repr(v), {"stim": lestim}) == v
 
 
 def test_hashable():
-    a = stim.DemInstruction("error", [0.25], [stim.target_relative_detector_id(3)])
-    b = stim.DemInstruction("error", [0.125], [stim.target_relative_detector_id(3)])
-    c = stim.DemInstruction("error", [0.25], [stim.target_relative_detector_id(3)])
+    a = lestim.DemInstruction("error", [0.25], [lestim.target_relative_detector_id(3)])
+    b = lestim.DemInstruction("error", [0.125], [lestim.target_relative_detector_id(3)])
+    c = lestim.DemInstruction("error", [0.25], [lestim.target_relative_detector_id(3)])
     assert hash(a) == hash(c)
     assert len({a, b, c}) == 2
 
 
 def test_target_groups():
-    dem = stim.DetectorErrorModel("detector D0")
-    assert dem[0].target_groups() == [[stim.DemTarget("D0")]]
+    dem = lestim.DetectorErrorModel("detector D0")
+    assert dem[0].target_groups() == [[lestim.DemTarget("D0")]]
 
 
 def test_init_from_str():
-    assert stim.DemInstruction("detector D0") == stim.DemInstruction("detector", [], [stim.target_relative_detector_id(0)])
+    assert lestim.DemInstruction("detector D0") == lestim.DemInstruction("detector", [], [lestim.target_relative_detector_id(0)])
 
     with pytest.raises(ValueError, match="single DemInstruction"):
-        stim.DemInstruction("")
+        lestim.DemInstruction("")
 
     with pytest.raises(ValueError, match="single DemInstruction"):
-        stim.DemInstruction("""
+        lestim.DemInstruction("""
             repeat 5 {
                 error(0.25) D0
                 shift_detectors 1
@@ -95,16 +95,16 @@ def test_init_from_str():
         """)
 
     with pytest.raises(ValueError, match="single DemInstruction"):
-        stim.DemInstruction("""
+        lestim.DemInstruction("""
             detector D0
             detector D1
         """)
 
 
 def test_tag():
-    assert stim.DemInstruction("error[test](0.25) D1").tag == 'test'
-    assert stim.DemInstruction("error", [0.25], [stim.DemTarget("D1")], tag="test").tag == 'test'
-    dem = stim.DetectorErrorModel('''
+    assert lestim.DemInstruction("error[test](0.25) D1").tag == 'test'
+    assert lestim.DemInstruction("error", [0.25], [lestim.DemTarget("D1")], tag="test").tag == 'test'
+    dem = lestim.DetectorErrorModel('''
         error[test-tag](0.125) D0
         error(0.125) D0
     ''')

--- a/src/stim/dem/detector_error_model_pybind_test.py
+++ b/src/stim/dem/detector_error_model_pybind_test.py
@@ -16,11 +16,11 @@ import tempfile
 
 import pytest
 
-import stim
+import lestim
 
 
 def test_init_get():
-    model = stim.DetectorErrorModel("""
+    model = lestim.DetectorErrorModel("""
         error(0.125) D0 L0
         ERROR(0.25) D0 ^ D1
         repeat 100 {
@@ -31,65 +31,65 @@ def test_init_get():
         shift_detectors 5
     """)
     assert len(model) == 5
-    assert model[0] == stim.DemInstruction(
+    assert model[0] == lestim.DemInstruction(
         "error",
         [0.125],
-        [stim.target_relative_detector_id(0), stim.target_logical_observable_id(0)])
-    assert model[1] == stim.DemInstruction(
+        [lestim.target_relative_detector_id(0), lestim.target_logical_observable_id(0)])
+    assert model[1] == lestim.DemInstruction(
         "error",
         [0.25],
-        [stim.target_relative_detector_id(0), stim.target_separator(), stim.target_relative_detector_id(1)])
-    assert model[2] == stim.DemRepeatBlock(
+        [lestim.target_relative_detector_id(0), lestim.target_separator(), lestim.target_relative_detector_id(1)])
+    assert model[2] == lestim.DemRepeatBlock(
         100,
-        stim.DetectorErrorModel("""
+        lestim.DetectorErrorModel("""
             shift_detectors 1
             error(0.125) D0 D1
         """))
-    assert model[3] == stim.DemInstruction(
+    assert model[3] == lestim.DemInstruction(
         "shift_detectors",
         [1, 1.5, 2, 2.5],
         [1])
-    assert model[4] == stim.DemInstruction(
+    assert model[4] == lestim.DemInstruction(
         "shift_detectors",
         [],
         [5])
 
 
 def test_equality():
-    assert stim.DetectorErrorModel() == stim.DetectorErrorModel()
-    assert not (stim.DetectorErrorModel() != stim.DetectorErrorModel())
-    assert not (stim.DetectorErrorModel() == stim.DetectorErrorModel("error(0.125) D0"))
-    assert stim.DetectorErrorModel() != stim.DetectorErrorModel("error(0.125) D0")
+    assert lestim.DetectorErrorModel() == lestim.DetectorErrorModel()
+    assert not (lestim.DetectorErrorModel() != lestim.DetectorErrorModel())
+    assert not (lestim.DetectorErrorModel() == lestim.DetectorErrorModel("error(0.125) D0"))
+    assert lestim.DetectorErrorModel() != lestim.DetectorErrorModel("error(0.125) D0")
 
-    assert stim.DetectorErrorModel("error(0.125) D0") == stim.DetectorErrorModel("error(0.125) D0")
-    assert stim.DetectorErrorModel("error(0.125) D0") != stim.DetectorErrorModel("error(0.126) D0")
-    assert stim.DetectorErrorModel("error(0.125) D0") != stim.DetectorErrorModel("detector(0.125) D0")
-    assert stim.DetectorErrorModel("error(0.125) D0") != stim.DetectorErrorModel("error(0.125) D1")
-    assert stim.DetectorErrorModel("error(0.125) D0") != stim.DetectorErrorModel("error(0.125) L0")
-    assert stim.DetectorErrorModel("error(0.125) D0") != stim.DetectorErrorModel("error(0.125) D0 D1")
-    assert stim.DetectorErrorModel("""
+    assert lestim.DetectorErrorModel("error(0.125) D0") == lestim.DetectorErrorModel("error(0.125) D0")
+    assert lestim.DetectorErrorModel("error(0.125) D0") != lestim.DetectorErrorModel("error(0.126) D0")
+    assert lestim.DetectorErrorModel("error(0.125) D0") != lestim.DetectorErrorModel("detector(0.125) D0")
+    assert lestim.DetectorErrorModel("error(0.125) D0") != lestim.DetectorErrorModel("error(0.125) D1")
+    assert lestim.DetectorErrorModel("error(0.125) D0") != lestim.DetectorErrorModel("error(0.125) L0")
+    assert lestim.DetectorErrorModel("error(0.125) D0") != lestim.DetectorErrorModel("error(0.125) D0 D1")
+    assert lestim.DetectorErrorModel("""
         REPEAT 3 {
             shift_detectors 4
         }
-    """) == stim.DetectorErrorModel("""
+    """) == lestim.DetectorErrorModel("""
         REPEAT 3 {
             shift_detectors 4
         }
     """)
-    assert stim.DetectorErrorModel("""
+    assert lestim.DetectorErrorModel("""
         REPEAT 3 {
             shift_detectors 4
         }
-    """) != stim.DetectorErrorModel("""
+    """) != lestim.DetectorErrorModel("""
         REPEAT 4 {
             shift_detectors 4
         }
     """)
-    assert stim.DetectorErrorModel("""
+    assert lestim.DetectorErrorModel("""
         REPEAT 3 {
             shift_detectors 4
         }
-    """) != stim.DetectorErrorModel("""
+    """) != lestim.DetectorErrorModel("""
         REPEAT 3 {
             shift_detectors 5
         }
@@ -97,40 +97,40 @@ def test_equality():
 
 
 def test_repr():
-    v = stim.DetectorErrorModel()
-    assert eval(repr(v), {"stim": stim}) == v
-    v = stim.DetectorErrorModel("error(0.125) D0 D1")
-    assert eval(repr(v), {"stim": stim}) == v
+    v = lestim.DetectorErrorModel()
+    assert eval(repr(v), {"stim": lestim}) == v
+    v = lestim.DetectorErrorModel("error(0.125) D0 D1")
+    assert eval(repr(v), {"stim": lestim}) == v
 
 
 def test_approx_equals():
-    base = stim.DetectorErrorModel("error(0.099) D0")
-    assert not base.approx_equals(stim.DetectorErrorModel("error(0.101) D0"), atol=0)
-    assert not base.approx_equals(stim.DetectorErrorModel("error(0.101) D0"), atol=0.00001)
-    assert base.approx_equals(stim.DetectorErrorModel("error(0.101) D0"), atol=0.01)
-    assert base.approx_equals(stim.DetectorErrorModel("error(0.101) D0"), atol=999)
-    assert not base.approx_equals(stim.DetectorErrorModel("error(0.101) D0 D1"), atol=999)
+    base = lestim.DetectorErrorModel("error(0.099) D0")
+    assert not base.approx_equals(lestim.DetectorErrorModel("error(0.101) D0"), atol=0)
+    assert not base.approx_equals(lestim.DetectorErrorModel("error(0.101) D0"), atol=0.00001)
+    assert base.approx_equals(lestim.DetectorErrorModel("error(0.101) D0"), atol=0.01)
+    assert base.approx_equals(lestim.DetectorErrorModel("error(0.101) D0"), atol=999)
+    assert not base.approx_equals(lestim.DetectorErrorModel("error(0.101) D0 D1"), atol=999)
 
     assert not base.approx_equals(object(), atol=999)
-    assert not base.approx_equals(stim.PauliString("XYZ"), atol=999)
+    assert not base.approx_equals(lestim.PauliString("XYZ"), atol=999)
 
 
 def test_append():
-    m = stim.DetectorErrorModel()
+    m = lestim.DetectorErrorModel()
     m.append("error", 0.125, [
-        stim.DemTarget.relative_detector_id(1),
+        lestim.DemTarget.relative_detector_id(1),
     ])
     m.append("error", 0.25, [
-        stim.DemTarget.relative_detector_id(1),
-        stim.DemTarget.separator(),
-        stim.DemTarget.relative_detector_id(2),
-        stim.DemTarget.logical_observable_id(3),
+        lestim.DemTarget.relative_detector_id(1),
+        lestim.DemTarget.separator(),
+        lestim.DemTarget.relative_detector_id(2),
+        lestim.DemTarget.logical_observable_id(3),
     ])
     m.append("shift_detectors", (1, 2, 3), [5])
     m += m * 3
     m.append(m[0])
     m.append(m[-2])
-    assert m == stim.DetectorErrorModel("""
+    assert m == lestim.DetectorErrorModel("""
         error(0.125) D1
         error(0.25) D1 ^ D2 L3
         shift_detectors(1, 2, 3) 5
@@ -149,16 +149,16 @@ def test_append():
 
 
 def test_append_bad():
-    m = stim.DetectorErrorModel()
-    m.append("error", 0.125, [stim.target_relative_detector_id(0)])
-    m.append("error", [0.125], [stim.target_relative_detector_id(0)])
+    m = lestim.DetectorErrorModel()
+    m.append("error", 0.125, [lestim.target_relative_detector_id(0)])
+    m.append("error", [0.125], [lestim.target_relative_detector_id(0)])
     m.append("shift_detectors", [], [5])
     m += m * 3
 
     with pytest.raises(ValueError, match=r"Bad target 'stim.DemTarget\('D0'\)' for instruction 'shift_detectors'"):
-        m.append("shift_detectors", [0.125, 0.25], [stim.target_relative_detector_id(0)])
+        m.append("shift_detectors", [0.125, 0.25], [lestim.target_relative_detector_id(0)])
     with pytest.raises(ValueError, match="takes 1 argument"):
-        m.append("error", [0.125, 0.25], [stim.target_relative_detector_id(0)])
+        m.append("error", [0.125, 0.25], [lestim.target_relative_detector_id(0)])
 
     with pytest.raises(ValueError, match="Bad target '0' for instruction 'error'"):
         m.append("error", [0.125], [0])
@@ -178,7 +178,7 @@ def test_append_bad():
 def test_pickle():
     import pickle
 
-    t = stim.DetectorErrorModel("""
+    t = lestim.DetectorErrorModel("""
         repeat 100 {
             error(0.25) D0 L1
             shift_detectors(1, 2) 3
@@ -189,16 +189,16 @@ def test_pickle():
 
 
 def test_count_errors():
-    assert stim.DetectorErrorModel().num_errors == 0
+    assert lestim.DetectorErrorModel().num_errors == 0
 
-    assert stim.DetectorErrorModel("""
+    assert lestim.DetectorErrorModel("""
         logical_observable L100
         detector D100
         shift_detectors(100, 100, 100) 100
         error(0.125) D100
     """).num_errors == 1
 
-    assert stim.DetectorErrorModel("""
+    assert lestim.DetectorErrorModel("""
         error(0.125) D0
         REPEAT 100 {
             REPEAT 5 {
@@ -210,41 +210,41 @@ def test_count_errors():
 
 def test_shortest_graphlike_error_trivial():
     with pytest.raises(ValueError, match="any graphlike logical errors"):
-        _ = stim.DetectorErrorModel().shortest_graphlike_error()
+        _ = lestim.DetectorErrorModel().shortest_graphlike_error()
     with pytest.raises(ValueError, match="any graphlike logical errors"):
-        _ = stim.DetectorErrorModel("""
+        _ = lestim.DetectorErrorModel("""
             error(0.1) D0
         """).shortest_graphlike_error()
     with pytest.raises(ValueError, match="any graphlike logical errors"):
-        _ = stim.DetectorErrorModel("""
+        _ = lestim.DetectorErrorModel("""
             error(0.1) D0 L0
         """).shortest_graphlike_error()
-    assert stim.DetectorErrorModel("""
+    assert lestim.DetectorErrorModel("""
         error(0.1) L0
-    """).shortest_graphlike_error() == stim.DetectorErrorModel("""
+    """).shortest_graphlike_error() == lestim.DetectorErrorModel("""
         error(1) L0
     """)
-    assert stim.DetectorErrorModel("""
+    assert lestim.DetectorErrorModel("""
         error(0.1) D0 D1 L0
         error(0.1) D0 D1
-    """).shortest_graphlike_error() == stim.DetectorErrorModel("""
+    """).shortest_graphlike_error() == lestim.DetectorErrorModel("""
         error(1) D0 D1
         error(1) D0 D1 L0
     """)
 
 
 def test_shortest_graphlike_error_line():
-    assert stim.DetectorErrorModel("""
+    assert lestim.DetectorErrorModel("""
         error(0.125) D0
         error(0.125) D0 D1
         error(0.125) D1 L55
         error(0.125) D1
-    """).shortest_graphlike_error() == stim.DetectorErrorModel("""
+    """).shortest_graphlike_error() == lestim.DetectorErrorModel("""
         error(1) D1
         error(1) D1 L55
     """)
 
-    assert len(stim.DetectorErrorModel("""
+    assert len(lestim.DetectorErrorModel("""
         error(0.1) D0 D1 L5
         REPEAT 1000 {
             error(0.1) D0 D2
@@ -257,16 +257,16 @@ def test_shortest_graphlike_error_line():
 
 
 def test_shortest_graphlike_error_ignore():
-    assert stim.DetectorErrorModel("""
+    assert lestim.DetectorErrorModel("""
         error(0.125) D0 D1 D2
         error(0.125) L0
-    """).shortest_graphlike_error(ignore_ungraphlike_errors=True) == stim.DetectorErrorModel("""
+    """).shortest_graphlike_error(ignore_ungraphlike_errors=True) == lestim.DetectorErrorModel("""
         error(1) L0
     """)
 
 
 def test_shortest_graphlike_error_rep_code():
-    circuit = stim.Circuit.generated("repetition_code:memory",
+    circuit = lestim.Circuit.generated("repetition_code:memory",
                                      rounds=10,
                                      distance=7,
                                      before_round_data_depolarization=0.01)
@@ -276,23 +276,23 @@ def test_shortest_graphlike_error_rep_code():
 
 def test_shortest_graphlike_error_msgs():
     with pytest.raises(ValueError, match=r"NO OBSERVABLES(.|\n)*NO DETECTORS(.|\n)*NO ERRORS"):
-        stim.Circuit().detector_error_model(decompose_errors=True).shortest_graphlike_error()
+        lestim.Circuit().detector_error_model(decompose_errors=True).shortest_graphlike_error()
 
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         M 0
         OBSERVABLE_INCLUDE(0) rec[-1]
     """)
     with pytest.raises(ValueError, match=r"NO DETECTORS(.|\n)*NO ERRORS"):
         c.detector_error_model(decompose_errors=True).shortest_graphlike_error()
 
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         X_ERROR(0.1) 0
         M 0
     """)
     with pytest.raises(ValueError, match=r"NO OBSERVABLES(.|\n)*NO DETECTORS(.|\n)*NO ERRORS"):
         c.detector_error_model(decompose_errors=True).shortest_graphlike_error()
 
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         M 0
         DETECTOR rec[-1]
         OBSERVABLE_INCLUDE(0) rec[-1]
@@ -300,7 +300,7 @@ def test_shortest_graphlike_error_msgs():
     with pytest.raises(ValueError, match=r"NO ERRORS"):
         c.detector_error_model(decompose_errors=True).shortest_graphlike_error()
 
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         X_ERROR(0.1) 0
         M 0
         DETECTOR rec[-1]
@@ -310,7 +310,7 @@ def test_shortest_graphlike_error_msgs():
 
 
 def test_coords():
-    circuit = stim.Circuit("""
+    circuit = lestim.Circuit("""
         M 0
         DETECTOR(1, 2, 3) rec[-1]
         REPEAT 3 {
@@ -351,16 +351,16 @@ def test_coords():
     assert circuit.get_detector_coordinates({1}) == {
         1: [2],
     }
-    assert dem.get_detector_coordinates(stim.DemTarget.relative_detector_id(1)) == {
+    assert dem.get_detector_coordinates(lestim.DemTarget.relative_detector_id(1)) == {
         1: [2],
     }
-    assert circuit.get_detector_coordinates(stim.DemTarget.relative_detector_id(1)) == {
+    assert circuit.get_detector_coordinates(lestim.DemTarget.relative_detector_id(1)) == {
         1: [2],
     }
-    assert dem.get_detector_coordinates((stim.DemTarget.relative_detector_id(1),)) == {
+    assert dem.get_detector_coordinates((lestim.DemTarget.relative_detector_id(1),)) == {
         1: [2],
     }
-    assert circuit.get_detector_coordinates((stim.DemTarget.relative_detector_id(1),)) == {
+    assert circuit.get_detector_coordinates((lestim.DemTarget.relative_detector_id(1),)) == {
         1: [2],
     }
 
@@ -385,46 +385,46 @@ def test_coords():
 
 def test_dem_from_file():
     with tempfile.TemporaryDirectory() as tmpdir:
-        path = tmpdir + '/tmp.stim'
+        path = tmpdir + '/tmp.lestim'
         with open(path, 'w') as f:
             print('error(0.125) D0 L5', file=f)
-        assert stim.DetectorErrorModel.from_file(path) == stim.DetectorErrorModel('error(0.125) D0 L5')
+        assert lestim.DetectorErrorModel.from_file(path) == lestim.DetectorErrorModel('error(0.125) D0 L5')
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        path = pathlib.Path(tmpdir) / 'tmp.stim'
+        path = pathlib.Path(tmpdir) / 'tmp.lestim'
         with open(path, 'w') as f:
             print('error(0.125) D0 L5', file=f)
-        assert stim.DetectorErrorModel.from_file(path) == stim.DetectorErrorModel('error(0.125) D0 L5')
+        assert lestim.DetectorErrorModel.from_file(path) == lestim.DetectorErrorModel('error(0.125) D0 L5')
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        path = tmpdir + '/tmp.stim'
+        path = tmpdir + '/tmp.lestim'
         with open(path, 'w') as f:
             print('error(0.125) D0 L5', file=f)
         with open(path) as f:
-            assert stim.DetectorErrorModel.from_file(f) == stim.DetectorErrorModel('error(0.125) D0 L5')
+            assert lestim.DetectorErrorModel.from_file(f) == lestim.DetectorErrorModel('error(0.125) D0 L5')
 
     with pytest.raises(ValueError, match="how to read"):
-        stim.DetectorErrorModel.from_file(object())
+        lestim.DetectorErrorModel.from_file(object())
     with pytest.raises(ValueError, match="how to read"):
-        stim.DetectorErrorModel.from_file(123)
+        lestim.DetectorErrorModel.from_file(123)
 
 
 def test_dem_to_file():
-    c = stim.DetectorErrorModel('error(0.125) D0 L5\n')
+    c = lestim.DetectorErrorModel('error(0.125) D0 L5\n')
     with tempfile.TemporaryDirectory() as tmpdir:
-        path = tmpdir + '/tmp.stim'
+        path = tmpdir + '/tmp.lestim'
         c.to_file(path)
         with open(path) as f:
             assert f.read() == 'error(0.125) D0 L5\n'
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        path = pathlib.Path(tmpdir) / 'tmp.stim'
+        path = pathlib.Path(tmpdir) / 'tmp.lestim'
         c.to_file(path)
         with open(path) as f:
             assert f.read() == 'error(0.125) D0 L5\n'
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        path = tmpdir + '/tmp.stim'
+        path = tmpdir + '/tmp.lestim'
         with open(path, 'w') as f:
             c.to_file(f)
         with open(path) as f:
@@ -437,57 +437,57 @@ def test_dem_to_file():
 
 
 def test_flattened():
-    dem = stim.DetectorErrorModel("""
+    dem = lestim.DetectorErrorModel("""
         shift_detectors 5
         repeat 2 {
             error(0.125) D0 D1
         }
     """)
-    assert dem.flattened() == stim.DetectorErrorModel("""
+    assert dem.flattened() == lestim.DetectorErrorModel("""
         error(0.125) D5 D6
         error(0.125) D5 D6
     """)
 
 
 def test_rounded():
-    dem = stim.DetectorErrorModel("""
+    dem = lestim.DetectorErrorModel("""
         error(0.1248) D0 D1
     """)
-    assert dem.rounded(1) == stim.DetectorErrorModel("""
+    assert dem.rounded(1) == lestim.DetectorErrorModel("""
         error(0.1) D0 D1
     """)
-    assert dem.rounded(2) == stim.DetectorErrorModel("""
+    assert dem.rounded(2) == lestim.DetectorErrorModel("""
         error(0.12) D0 D1
     """)
-    assert dem.rounded(3) == stim.DetectorErrorModel("""
+    assert dem.rounded(3) == lestim.DetectorErrorModel("""
         error(0.125) D0 D1
     """)
-    assert dem.rounded(4) == stim.DetectorErrorModel("""
+    assert dem.rounded(4) == lestim.DetectorErrorModel("""
         error(0.1248) D0 D1
     """)
-    assert dem.rounded(5) == stim.DetectorErrorModel("""
+    assert dem.rounded(5) == lestim.DetectorErrorModel("""
         error(0.1248) D0 D1
     """)
 
-    dem = stim.DetectorErrorModel("""
+    dem = lestim.DetectorErrorModel("""
         error(0.01248) D0 D1
     """)
-    assert dem.rounded(1) == stim.DetectorErrorModel("""
+    assert dem.rounded(1) == lestim.DetectorErrorModel("""
         error(0) D0 D1
     """)
-    assert dem.rounded(2) == stim.DetectorErrorModel("""
+    assert dem.rounded(2) == lestim.DetectorErrorModel("""
         error(0.01) D0 D1
     """)
-    assert dem.rounded(3) == stim.DetectorErrorModel("""
+    assert dem.rounded(3) == lestim.DetectorErrorModel("""
         error(0.012) D0 D1
     """)
-    assert dem.rounded(4) == stim.DetectorErrorModel("""
+    assert dem.rounded(4) == lestim.DetectorErrorModel("""
         error(0.0125) D0 D1
     """)
 
 
 def test_diagram():
-    circuit = stim.Circuit.generated("repetition_code:memory",
+    circuit = lestim.Circuit.generated("repetition_code:memory",
                                      rounds=10,
                                      distance=7,
                                      before_round_data_depolarization=0.01)
@@ -503,7 +503,7 @@ def test_diagram():
 
 
 def test_shortest_graphlike_error_remnant():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         X_ERROR(0.125) 0 1 2 3 4 5 6 7 10
         E(0.125) X2 X3 X10
         M 0 1 2 3 4 5 6 7 10
@@ -517,7 +517,7 @@ def test_shortest_graphlike_error_remnant():
         DETECTOR rec[-7] rec[-8]
         DETECTOR rec[-8] rec[-9]
     """)
-    d = stim.DetectorErrorModel("""
+    d = lestim.DetectorErrorModel("""
         error(0.125) D0
         error(0.125) D0 ^ D4 D6
         error(0.125) D1 D2
@@ -539,27 +539,27 @@ def test_shortest_graphlike_error_remnant():
 
 
 def test_init_parse():
-    assert stim.DemInstruction("error(0.125) D0 D1") == stim.DemInstruction("error", [0.125], [stim.DemTarget("D0"), stim.DemTarget("D1")])
+    assert lestim.DemInstruction("error(0.125) D0 D1") == lestim.DemInstruction("error", [0.125], [lestim.DemTarget("D0"), lestim.DemTarget("D1")])
 
 
 def test_without_tags():
-    dem = stim.DetectorErrorModel("""
+    dem = lestim.DetectorErrorModel("""
         error[tag](0.25) D5
     """)
-    assert dem.without_tags() == stim.DetectorErrorModel("""
+    assert dem.without_tags() == lestim.DetectorErrorModel("""
         error(0.25) D5
     """)
 
 
 def test_append_dem_to_dem():
-    dem = stim.DetectorErrorModel("""
+    dem = lestim.DetectorErrorModel("""
         error(0.25) D0
     """)
-    dem.append(stim.DetectorErrorModel("""
+    dem.append(lestim.DetectorErrorModel("""
         error(0.125) D1
         error(0.25) D2
     """))
-    assert dem == stim.DetectorErrorModel("""
+    assert dem == lestim.DetectorErrorModel("""
         error(0.25) D0
         error(0.125) D1
         error(0.25) D2

--- a/src/stim/dem/detector_error_model_repeat_block_pybind_test.py
+++ b/src/stim/dem/detector_error_model_repeat_block_pybind_test.py
@@ -12,33 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import stim
+import lestim
 
 
 def test_init_vs_properties():
-    v = stim.DemRepeatBlock(5, stim.DetectorErrorModel('error(0.125) D1 L2'))
+    v = lestim.DemRepeatBlock(5, lestim.DetectorErrorModel('error(0.125) D1 L2'))
     assert v.repeat_count == 5
-    assert v.body_copy() == stim.DetectorErrorModel('error(0.125) D1 L2')
+    assert v.body_copy() == lestim.DetectorErrorModel('error(0.125) D1 L2')
     assert v.body_copy() is not v.body_copy()
 
 
 def test_equality():
-    m0 = stim.DetectorErrorModel()
-    m1 = stim.DetectorErrorModel('error(0.125) D1 L2')
-    assert stim.DemRepeatBlock(5, m0) == stim.DemRepeatBlock(5, m0)
-    assert not (stim.DemRepeatBlock(5, m0) != stim.DemRepeatBlock(5, m0))
-    assert stim.DemRepeatBlock(5, m0) != stim.DemRepeatBlock(5, m1)
-    assert not (stim.DemRepeatBlock(5, m0) == stim.DemRepeatBlock(5, m1))
-    assert stim.DemRepeatBlock(5, m0) != stim.DemRepeatBlock(6, m0)
+    m0 = lestim.DetectorErrorModel()
+    m1 = lestim.DetectorErrorModel('error(0.125) D1 L2')
+    assert lestim.DemRepeatBlock(5, m0) == lestim.DemRepeatBlock(5, m0)
+    assert not (lestim.DemRepeatBlock(5, m0) != lestim.DemRepeatBlock(5, m0))
+    assert lestim.DemRepeatBlock(5, m0) != lestim.DemRepeatBlock(5, m1)
+    assert not (lestim.DemRepeatBlock(5, m0) == lestim.DemRepeatBlock(5, m1))
+    assert lestim.DemRepeatBlock(5, m0) != lestim.DemRepeatBlock(6, m0)
 
 
 def test_repr():
-    v = stim.DemRepeatBlock(5, stim.DetectorErrorModel('error(0.125) D1 L2'))
-    assert eval(repr(v), {"stim": stim}) == v
+    v = lestim.DemRepeatBlock(5, lestim.DetectorErrorModel('error(0.125) D1 L2'))
+    assert eval(repr(v), {"stim": lestim}) == v
 
 
 def test_type():
-    assert [e.type for e in stim.DetectorErrorModel('''
+    assert [e.type for e in lestim.DetectorErrorModel('''
         detector D0
         REPEAT 5 {
             error(0.1) D0

--- a/src/stim/dem/detector_error_model_target_pybind_test.py
+++ b/src/stim/dem/detector_error_model_target_pybind_test.py
@@ -13,85 +13,85 @@
 # limitations under the License.
 
 import pytest
-import stim
+import lestim
 
 
 def test_equality():
-    assert stim.target_relative_detector_id(5) == stim.target_relative_detector_id(5)
-    assert not (stim.target_relative_detector_id(5) != stim.target_relative_detector_id(5))
-    assert stim.target_relative_detector_id(4) != stim.target_relative_detector_id(5)
-    assert not (stim.target_relative_detector_id(4) == stim.target_relative_detector_id(5))
+    assert lestim.target_relative_detector_id(5) == lestim.target_relative_detector_id(5)
+    assert not (lestim.target_relative_detector_id(5) != lestim.target_relative_detector_id(5))
+    assert lestim.target_relative_detector_id(4) != lestim.target_relative_detector_id(5)
+    assert not (lestim.target_relative_detector_id(4) == lestim.target_relative_detector_id(5))
 
-    assert stim.target_relative_detector_id(5) != stim.target_logical_observable_id(5)
-    assert stim.target_logical_observable_id(5) == stim.target_logical_observable_id(5)
-    assert stim.target_relative_detector_id(5) != stim.target_separator()
-    assert stim.target_separator() == stim.target_separator()
+    assert lestim.target_relative_detector_id(5) != lestim.target_logical_observable_id(5)
+    assert lestim.target_logical_observable_id(5) == lestim.target_logical_observable_id(5)
+    assert lestim.target_relative_detector_id(5) != lestim.target_separator()
+    assert lestim.target_separator() == lestim.target_separator()
 
 
 def test_str():
-    assert str(stim.target_relative_detector_id(5)) == "D5"
-    assert str(stim.target_logical_observable_id(6)) == "L6"
-    assert str(stim.target_separator()) == "^"
+    assert str(lestim.target_relative_detector_id(5)) == "D5"
+    assert str(lestim.target_logical_observable_id(6)) == "L6"
+    assert str(lestim.target_separator()) == "^"
 
 
 def test_properties():
-    assert stim.target_relative_detector_id(6).val == 6
-    assert stim.target_relative_detector_id(5).val == 5
-    assert stim.target_relative_detector_id(5).is_relative_detector_id()
-    assert not stim.target_relative_detector_id(5).is_logical_observable_id()
-    assert not stim.target_relative_detector_id(5).is_separator()
+    assert lestim.target_relative_detector_id(6).val == 6
+    assert lestim.target_relative_detector_id(5).val == 5
+    assert lestim.target_relative_detector_id(5).is_relative_detector_id()
+    assert not lestim.target_relative_detector_id(5).is_logical_observable_id()
+    assert not lestim.target_relative_detector_id(5).is_separator()
 
-    assert stim.target_logical_observable_id(6).val == 6
-    assert stim.target_logical_observable_id(5).val == 5
-    assert not stim.target_logical_observable_id(5).is_relative_detector_id()
-    assert stim.target_logical_observable_id(5).is_logical_observable_id()
-    assert not stim.target_logical_observable_id(5).is_separator()
+    assert lestim.target_logical_observable_id(6).val == 6
+    assert lestim.target_logical_observable_id(5).val == 5
+    assert not lestim.target_logical_observable_id(5).is_relative_detector_id()
+    assert lestim.target_logical_observable_id(5).is_logical_observable_id()
+    assert not lestim.target_logical_observable_id(5).is_separator()
 
-    assert not stim.target_separator().is_relative_detector_id()
-    assert not stim.target_separator().is_logical_observable_id()
-    assert stim.target_separator().is_separator()
+    assert not lestim.target_separator().is_relative_detector_id()
+    assert not lestim.target_separator().is_logical_observable_id()
+    assert lestim.target_separator().is_separator()
     with pytest.raises(ValueError, match="Separator"):
-        _ = stim.target_separator().val
+        _ = lestim.target_separator().val
 
 
 def test_repr():
-    v = stim.target_relative_detector_id(5)
-    assert eval(repr(v), {"stim": stim}) == v
-    v = stim.target_logical_observable_id(6)
-    assert eval(repr(v), {"stim": stim}) == v
-    v = stim.target_separator()
-    assert eval(repr(v), {"stim": stim}) == v
+    v = lestim.target_relative_detector_id(5)
+    assert eval(repr(v), {"stim": lestim}) == v
+    v = lestim.target_logical_observable_id(6)
+    assert eval(repr(v), {"stim": lestim}) == v
+    v = lestim.target_separator()
+    assert eval(repr(v), {"stim": lestim}) == v
 
 
 def test_static_constructors():
-    assert stim.DemTarget.relative_detector_id(5) == stim.target_relative_detector_id(5)
-    assert stim.DemTarget.logical_observable_id(5) == stim.target_logical_observable_id(5)
-    assert stim.DemTarget.separator() == stim.target_separator()
+    assert lestim.DemTarget.relative_detector_id(5) == lestim.target_relative_detector_id(5)
+    assert lestim.DemTarget.logical_observable_id(5) == lestim.target_logical_observable_id(5)
+    assert lestim.DemTarget.separator() == lestim.target_separator()
 
 
 def test_hashable():
-    a = stim.DemTarget.relative_detector_id(3)
-    b = stim.DemTarget.logical_observable_id(5)
-    c = stim.DemTarget.relative_detector_id(3)
+    a = lestim.DemTarget.relative_detector_id(3)
+    b = lestim.DemTarget.logical_observable_id(5)
+    c = lestim.DemTarget.relative_detector_id(3)
     assert hash(a) == hash(c)
     assert len({a, b, c}) == 2
 
 
 def test_init():
-    assert stim.DemTarget("D0") == stim.target_relative_detector_id(0)
-    assert stim.DemTarget("D5") == stim.target_relative_detector_id(5)
-    assert stim.DemTarget("L0") == stim.target_logical_observable_id(0)
-    assert stim.DemTarget("L5") == stim.target_logical_observable_id(5)
-    assert stim.DemTarget("^") == stim.target_separator()
-    assert stim.DemTarget(f"D{2**62 - 1}") == stim.target_relative_detector_id(2**62 - 1)
-    assert stim.DemTarget(f"L{0xFFFFFFFF}") == stim.target_logical_observable_id(0xFFFFFFFF)
+    assert lestim.DemTarget("D0") == lestim.target_relative_detector_id(0)
+    assert lestim.DemTarget("D5") == lestim.target_relative_detector_id(5)
+    assert lestim.DemTarget("L0") == lestim.target_logical_observable_id(0)
+    assert lestim.DemTarget("L5") == lestim.target_logical_observable_id(5)
+    assert lestim.DemTarget("^") == lestim.target_separator()
+    assert lestim.DemTarget(f"D{2**62 - 1}") == lestim.target_relative_detector_id(2**62 - 1)
+    assert lestim.DemTarget(f"L{0xFFFFFFFF}") == lestim.target_logical_observable_id(0xFFFFFFFF)
     with pytest.raises(ValueError, match="Failed to parse"):
-        _ = stim.DemTarget(f"D{2**62}")
+        _ = lestim.DemTarget(f"D{2**62}")
     with pytest.raises(ValueError, match="Failed to parse"):
-        _ = stim.DemTarget(f"L{0x100000000}")
+        _ = lestim.DemTarget(f"L{0x100000000}")
     with pytest.raises(ValueError, match="Failed to parse"):
-        _ = stim.DemTarget(f"L-1")
+        _ = lestim.DemTarget(f"L-1")
     with pytest.raises(ValueError, match="Failed to parse"):
-        _ = stim.DemTarget(f"X5")
+        _ = lestim.DemTarget(f"X5")
     with pytest.raises(ValueError, match="Failed to parse"):
-        _ = stim.DemTarget(f"5")
+        _ = lestim.DemTarget(f"5")

--- a/src/stim/gates/gates_test.py
+++ b/src/stim/gates/gates_test.py
@@ -1,16 +1,16 @@
 import numpy as np
-import stim
+import lestim
 
 
 def test_gate_data_eq():
-    assert stim.gate_data('H') == stim.GateData('H')
-    assert stim.gate_data('H') == stim.gate_data('H_XZ')
-    assert not (stim.gate_data('H') == stim.GateData('X_ERROR'))
-    assert stim.gate_data('X') != stim.GateData('H')
+    assert lestim.gate_data('H') == lestim.GateData('H')
+    assert lestim.gate_data('H') == lestim.gate_data('H_XZ')
+    assert not (lestim.gate_data('H') == lestim.GateData('X_ERROR'))
+    assert lestim.gate_data('X') != lestim.GateData('H')
 
 
 def test_gate_data_str():
-    assert str(stim.GateData('MXX')) == '''
+    assert str(lestim.GateData('MXX')) == '''
 stim.GateData {
     .name = 'MXX'
     .aliases = ['MXX']
@@ -25,7 +25,7 @@ stim.GateData {
     .takes_pauli_targets = False
 }
     '''.strip()
-    assert str(stim.GateData('H')) == '''
+    assert str(lestim.GateData('H')) == '''
 stim.GateData {
     .name = 'H'
     .aliases = ['H', 'H_XZ']
@@ -52,66 +52,66 @@ stim.GateData {
 
 
 def test_num_parens_arguments_range():
-    assert stim.gate_data('H').num_parens_arguments_range == range(0, 1)
-    assert stim.gate_data('M').num_parens_arguments_range == range(0, 2)
+    assert lestim.gate_data('H').num_parens_arguments_range == range(0, 1)
+    assert lestim.gate_data('M').num_parens_arguments_range == range(0, 2)
 
 
 def test_is_reset():
-    assert not stim.gate_data('H').is_reset
-    assert stim.gate_data('R').is_reset
-    assert stim.gate_data('MR').is_reset
+    assert not lestim.gate_data('H').is_reset
+    assert lestim.gate_data('R').is_reset
+    assert lestim.gate_data('MR').is_reset
 
 
 def test_is_two_qubit_gate():
-    assert not stim.gate_data('H').is_two_qubit_gate
-    assert stim.gate_data('CX').is_two_qubit_gate
+    assert not lestim.gate_data('H').is_two_qubit_gate
+    assert lestim.gate_data('CX').is_two_qubit_gate
 
 
 def test_is_single_qubit_gate():
-    assert stim.gate_data('H').is_single_qubit_gate
-    assert not stim.gate_data('CX').is_single_qubit_gate
+    assert lestim.gate_data('H').is_single_qubit_gate
+    assert not lestim.gate_data('CX').is_single_qubit_gate
 
 
 def test_is_noisy_gate():
-    assert stim.gate_data('X_ERROR').is_noisy_gate
-    assert not stim.gate_data('X').is_noisy_gate
+    assert lestim.gate_data('X_ERROR').is_noisy_gate
+    assert not lestim.gate_data('X').is_noisy_gate
 
 
 def test_produces_measurements():
-    assert stim.gate_data('MR').produces_measurements
-    assert not stim.gate_data('R').produces_measurements
+    assert lestim.gate_data('MR').produces_measurements
+    assert not lestim.gate_data('R').produces_measurements
 
 
 def test_takes_pauli_targets():
-    assert stim.gate_data('MPP').takes_pauli_targets
-    assert not stim.gate_data('MXX').takes_pauli_targets
+    assert lestim.gate_data('MPP').takes_pauli_targets
+    assert not lestim.gate_data('MXX').takes_pauli_targets
 
 
 def test_aliases():
-    assert stim.gate_data('H').aliases == ['H', 'H_XZ']
-    assert stim.gate_data('CX').aliases == ['CNOT', 'CX', 'ZCX']
+    assert lestim.gate_data('H').aliases == ['H', 'H_XZ']
+    assert lestim.gate_data('CX').aliases == ['CNOT', 'CX', 'ZCX']
 
 
 def test_tableau():
-    assert stim.gate_data('H').tableau == stim.Tableau.from_named_gate('H')
+    assert lestim.gate_data('H').tableau == lestim.Tableau.from_named_gate('H')
 
 
 def test_name():
-    assert stim.gate_data('H').name == 'H'
+    assert lestim.gate_data('H').name == 'H'
 
 
 def test_gate_data_repr():
-    val = stim.GateData('MPP')
-    assert eval(repr(val), {"stim": stim}) == val
+    val = lestim.GateData('MPP')
+    assert eval(repr(val), {"stim": lestim}) == val
 
 
 def test_takes_measurement_record_targets():
-    assert not stim.gate_data('H').takes_measurement_record_targets
-    assert stim.gate_data('DETECTOR').takes_measurement_record_targets
+    assert not lestim.gate_data('H').takes_measurement_record_targets
+    assert lestim.gate_data('DETECTOR').takes_measurement_record_targets
 
 
 def test_gate_data_inverse():
-    for v in stim.gate_data().values():
+    for v in lestim.gate_data().values():
         assert v.is_unitary == (v.inverse is not None)
         matrix = v.unitary_matrix
         if matrix is not None:
@@ -119,44 +119,44 @@ def test_gate_data_inverse():
             assert np.allclose(matrix.conj().T, v.inverse.unitary_matrix, atol=1e-6), (v.name, v.inverse.name)
             assert v.inverse == v.generalized_inverse
 
-    assert stim.gate_data('H').inverse == stim.gate_data('H')
-    assert stim.gate_data('S').inverse == stim.gate_data('S_DAG')
-    assert stim.gate_data('M').inverse is None
-    assert stim.gate_data('CXSWAP').inverse == stim.gate_data('SWAPCX')
-    assert stim.gate_data('SPP').inverse == stim.gate_data('SPP_DAG')
+    assert lestim.gate_data('H').inverse == lestim.gate_data('H')
+    assert lestim.gate_data('S').inverse == lestim.gate_data('S_DAG')
+    assert lestim.gate_data('M').inverse is None
+    assert lestim.gate_data('CXSWAP').inverse == lestim.gate_data('SWAPCX')
+    assert lestim.gate_data('SPP').inverse == lestim.gate_data('SPP_DAG')
 
-    assert stim.gate_data('S').generalized_inverse == stim.gate_data('S_DAG')
-    assert stim.gate_data('M').generalized_inverse == stim.gate_data('M')
-    assert stim.gate_data('R').generalized_inverse == stim.gate_data('M')
-    assert stim.gate_data('MR').generalized_inverse == stim.gate_data('MR')
-    assert stim.gate_data('MPP').generalized_inverse == stim.gate_data('MPP')
-    assert stim.gate_data('ELSE_CORRELATED_ERROR').generalized_inverse == stim.gate_data('ELSE_CORRELATED_ERROR')
+    assert lestim.gate_data('S').generalized_inverse == lestim.gate_data('S_DAG')
+    assert lestim.gate_data('M').generalized_inverse == lestim.gate_data('M')
+    assert lestim.gate_data('R').generalized_inverse == lestim.gate_data('M')
+    assert lestim.gate_data('MR').generalized_inverse == lestim.gate_data('MR')
+    assert lestim.gate_data('MPP').generalized_inverse == lestim.gate_data('MPP')
+    assert lestim.gate_data('ELSE_CORRELATED_ERROR').generalized_inverse == lestim.gate_data('ELSE_CORRELATED_ERROR')
 
 
 def test_gate_data_flows():
-    assert stim.GateData('H').flows == [
-        stim.Flow("X -> Z"),
-        stim.Flow("Z -> X"),
+    assert lestim.GateData('H').flows == [
+        lestim.Flow("X -> Z"),
+        lestim.Flow("Z -> X"),
     ]
 
 
 def test_gate_is_symmetric():
-    assert stim.GateData('SWAP').is_symmetric_gate
-    assert stim.GateData('H').is_symmetric_gate
-    assert stim.GateData('MYY').is_symmetric_gate
-    assert stim.GateData('DEPOLARIZE2').is_symmetric_gate
-    assert not stim.GateData('PAULI_CHANNEL_2').is_symmetric_gate
-    assert not stim.GateData('DETECTOR').is_symmetric_gate
-    assert not stim.GateData('TICK').is_symmetric_gate
+    assert lestim.GateData('SWAP').is_symmetric_gate
+    assert lestim.GateData('H').is_symmetric_gate
+    assert lestim.GateData('MYY').is_symmetric_gate
+    assert lestim.GateData('DEPOLARIZE2').is_symmetric_gate
+    assert not lestim.GateData('PAULI_CHANNEL_2').is_symmetric_gate
+    assert not lestim.GateData('DETECTOR').is_symmetric_gate
+    assert not lestim.GateData('TICK').is_symmetric_gate
 
 
 def test_gate_hadamard_conjugated():
-    assert stim.GateData('CZSWAP').hadamard_conjugated(unsigned=True) is None
-    assert stim.GateData('TICK').hadamard_conjugated() == stim.GateData('TICK')
-    assert stim.GateData('MYY').hadamard_conjugated() == stim.GateData('MYY')
-    assert stim.GateData('XCZ').hadamard_conjugated() == stim.GateData('CX')
-    assert stim.GateData('X_ERROR').hadamard_conjugated() == stim.GateData('Z_ERROR')
-    assert stim.GateData('Y_ERROR').hadamard_conjugated() == stim.GateData('Y_ERROR')
-    assert stim.GateData('Z_ERROR').hadamard_conjugated() == stim.GateData('X_ERROR')
-    assert stim.GateData('I_ERROR').hadamard_conjugated() == stim.GateData('I_ERROR')
-    assert stim.GateData('II_ERROR').hadamard_conjugated() == stim.GateData('II_ERROR')
+    assert lestim.GateData('CZSWAP').hadamard_conjugated(unsigned=True) is None
+    assert lestim.GateData('TICK').hadamard_conjugated() == lestim.GateData('TICK')
+    assert lestim.GateData('MYY').hadamard_conjugated() == lestim.GateData('MYY')
+    assert lestim.GateData('XCZ').hadamard_conjugated() == lestim.GateData('CX')
+    assert lestim.GateData('X_ERROR').hadamard_conjugated() == lestim.GateData('Z_ERROR')
+    assert lestim.GateData('Y_ERROR').hadamard_conjugated() == lestim.GateData('Y_ERROR')
+    assert lestim.GateData('Z_ERROR').hadamard_conjugated() == lestim.GateData('X_ERROR')
+    assert lestim.GateData('I_ERROR').hadamard_conjugated() == lestim.GateData('I_ERROR')
+    assert lestim.GateData('II_ERROR').hadamard_conjugated() == lestim.GateData('II_ERROR')

--- a/src/stim/io/stim_data_formats.cc
+++ b/src/stim/io/stim_data_formats.cc
@@ -20,11 +20,11 @@ This is the default format used by Stim, because it's the easiest to understand.
 *Example of producing 01 format data using stim's python API:*
 
     >>> import pathlib
-    >>> import stim
+    >>> import lestim
     >>> import tempfile
     >>> with tempfile.TemporaryDirectory() as d:
     ...     path = str(pathlib.Path(d) / "tmp.dat")
-    ...     stim.Circuit("""
+    ...     lestim.Circuit("""
     ...         X 1
     ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
     ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="01")
@@ -88,11 +88,11 @@ This format requires the reader to know the number of bits in each shot.
 *Example of producing b8 format data using stim's python API:*
 
     >>> import pathlib
-    >>> import stim
+    >>> import lestim
     >>> import tempfile
     >>> with tempfile.TemporaryDirectory() as d:
     ...     path = str(pathlib.Path(d) / "tmp.dat")
-    ...     stim.Circuit("""
+    ...     lestim.Circuit("""
     ...         X 1
     ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
     ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="b8")
@@ -157,11 +157,11 @@ where it is possible to parallelize across shots using SIMD instructions.
 *Example of producing ptb64 format data using stim's python API:*
 
     >>> import pathlib
-    >>> import stim
+    >>> import lestim
     >>> import tempfile
     >>> with tempfile.TemporaryDirectory() as d:
     ...     path = str(pathlib.Path(d) / "tmp.dat")
-    ...     stim.Circuit("""
+    ...     lestim.Circuit("""
     ...         X 1
     ...         M 0 1
     ...     """).compile_sampler().sample_write(shots=64, filepath=path, format="ptb64")
@@ -233,11 +233,11 @@ events.
 *Example of producing hits format data using stim's python API:*
 
     >>> import pathlib
-    >>> import stim
+    >>> import lestim
     >>> import tempfile
     >>> with tempfile.TemporaryDirectory() as d:
     ...     path = str(pathlib.Path(d) / "tmp.dat")
-    ...     stim.Circuit("""
+    ...     lestim.Circuit("""
     ...         X 1
     ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
     ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="hits")
@@ -302,11 +302,11 @@ events.
 *Example of producing r8 format data using stim's python API:*
 
     >>> import pathlib
-    >>> import stim
+    >>> import lestim
     >>> import tempfile
     >>> with tempfile.TemporaryDirectory() as d:
     ...     path = str(pathlib.Path(d) / "tmp.dat")
-    ...     stim.Circuit("""
+    ...     lestim.Circuit("""
     ...         X 1
     ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
     ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="r8")
@@ -316,7 +316,7 @@ events.
 
     >>> with tempfile.TemporaryDirectory() as d:
     ...     path = str(pathlib.Path(d) / "tmp.dat")
-    ...     stim.Circuit("""
+    ...     lestim.Circuit("""
     ...         X 1
     ...         M 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
     ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="r8")
@@ -385,11 +385,11 @@ wants to produce vectors of bits instead of sets.
 *Example of producing dets format data using stim's python API:*
 
     >>> import pathlib
-    >>> import stim
+    >>> import lestim
     >>> import tempfile
     >>> with tempfile.TemporaryDirectory() as d:
     ...     path = str(pathlib.Path(d) / "tmp.dat")
-    ...     stim.Circuit("""
+    ...     lestim.Circuit("""
     ...         X 1
     ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1 0 1
     ...     """).compile_sampler().sample_write(shots=3, filepath=path, format="dets")
@@ -401,7 +401,7 @@ wants to produce vectors of bits instead of sets.
 
     >>> with tempfile.TemporaryDirectory() as d:
     ...     path = str(pathlib.Path(d) / "tmp.dat")
-    ...     stim.Circuit("""
+    ...     lestim.Circuit("""
     ...         X_ERROR(1) 1
     ...         M 0 1 2
     ...         DETECTOR rec[-1]

--- a/src/stim/py/compiled_detector_sampler_pybind_test.py
+++ b/src/stim/py/compiled_detector_sampler_pybind_test.py
@@ -17,11 +17,11 @@ import tempfile
 
 import numpy as np
 import pytest
-import stim
+import lestim
 
 
 def test_compiled_detector_sampler_trivial():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         X_ERROR(1) 0
         M 0
         DETECTOR rec[-1]
@@ -35,7 +35,7 @@ def test_compiled_detector_sampler_trivial():
 
 
 def test_compiled_detector_sampler_sample():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         X_ERROR(1) 0
         M 0 1 2
         DETECTOR rec[-3] rec[-2]
@@ -160,7 +160,7 @@ def test_compiled_detector_sampler_sample():
 
 
 def test_write_obs_file():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         X_ERROR(1) 1
         MR 0 1
         DETECTOR rec[-2]
@@ -172,7 +172,7 @@ def test_write_obs_file():
         OBSERVABLE_INCLUDE(1) rec[-1]
         OBSERVABLE_INCLUDE(2) rec[-2]
     """)
-    r: stim.CompiledDetectorSampler = c.compile_detector_sampler()
+    r: lestim.CompiledDetectorSampler = c.compile_detector_sampler()
     with tempfile.TemporaryDirectory() as d:
         d = pathlib.Path(d)
         r.sample_write(
@@ -202,7 +202,7 @@ def test_write_obs_file():
             assert f.read() == '1\n' * 100
 
 def test_detector_sampler_actually_fills_array():
-    circuit = stim.Circuit('''
+    circuit = lestim.Circuit('''
        X_ERROR(1) 0
        M 0
        DETECTOR rec[-1]
@@ -213,7 +213,7 @@ def test_detector_sampler_actually_fills_array():
 
 
 def test_manual_output_buffer():
-    circuit = stim.Circuit('''
+    circuit = lestim.Circuit('''
         X_ERROR(1) 0
         M 0
         DETECTOR

--- a/src/stim/py/compiled_measurement_sampler_pybind_test.py
+++ b/src/stim/py/compiled_measurement_sampler_pybind_test.py
@@ -15,11 +15,11 @@ import tempfile
 
 import numpy as np
 import pytest
-import stim
+import lestim
 
 
 def test_compiled_measurement_sampler_sample():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         X 1
         M 0 1 2 3
     """)
@@ -53,7 +53,7 @@ def test_compiled_measurement_sampler_sample():
 
 
 def test_measurements_vs_resets():
-    assert not np.any(stim.Circuit("""
+    assert not np.any(lestim.Circuit("""
         RX 0
         RY 1
         RZ 2
@@ -62,7 +62,7 @@ def test_measurements_vs_resets():
         M 0 1 2
     """).compile_sampler().sample(shots=100))
 
-    assert not np.any(stim.Circuit("""
+    assert not np.any(lestim.Circuit("""
         H 0
         H_YZ 1
         MRX 0
@@ -73,7 +73,7 @@ def test_measurements_vs_resets():
         M 0 1 2
     """).compile_sampler().sample(shots=100))
 
-    assert not np.any(stim.Circuit("""
+    assert not np.any(lestim.Circuit("""
         H 0
         H_YZ 1
         MRX 0
@@ -83,7 +83,7 @@ def test_measurements_vs_resets():
 
 
 def test_sample_write():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         X 0 4 5
         M 0 1 2 3 4 5 6
     """)
@@ -100,32 +100,32 @@ def test_sample_write():
 
 def test_skip_reference_sample():
     np.testing.assert_array_equal(
-        stim.Circuit("X 0\nM 0").compile_sampler().sample(1),
+        lestim.Circuit("X 0\nM 0").compile_sampler().sample(1),
         [[True]],
     )
     np.testing.assert_array_equal(
-        stim.Circuit("X 0\nM 0").compile_sampler(skip_reference_sample=False).sample(1),
+        lestim.Circuit("X 0\nM 0").compile_sampler(skip_reference_sample=False).sample(1),
         [[True]],
     )
     np.testing.assert_array_equal(
-        stim.Circuit("X 0\nM 0").compile_sampler(skip_reference_sample=True).sample(1),
+        lestim.Circuit("X 0\nM 0").compile_sampler(skip_reference_sample=True).sample(1),
         [[False]],
     )
     np.testing.assert_array_equal(
-        stim.Circuit("X_ERROR(1) 0\nM 0").compile_sampler(skip_reference_sample=False).sample(1),
+        lestim.Circuit("X_ERROR(1) 0\nM 0").compile_sampler(skip_reference_sample=False).sample(1),
         [[True]],
     )
     np.testing.assert_array_equal(
-        stim.Circuit("X_ERROR(1) 0\nM 0").compile_sampler(skip_reference_sample=True).sample(1),
+        lestim.Circuit("X_ERROR(1) 0\nM 0").compile_sampler(skip_reference_sample=True).sample(1),
         [[True]],
     )
 
 def test_reference_sample_init():
     np.testing.assert_array_equal(
-        stim.Circuit("X 0\nM 0").compile_sampler(reference_sample=None).sample(1),
+        lestim.Circuit("X 0\nM 0").compile_sampler(reference_sample=None).sample(1),
         [[True]],
     )
-    circuit = stim.Circuit("X 0\nM 0")
+    circuit = lestim.Circuit("X 0\nM 0")
     ref_sample = np.array([False])
     np.testing.assert_array_equal(
         circuit.compile_sampler(reference_sample=ref_sample).sample(1),
@@ -136,7 +136,7 @@ def test_reference_sample_init():
         circuit.compile_sampler(reference_sample=ref_sample).sample(1),
         [[True]],
     )
-    circuit = stim.Circuit("X_ERROR(1) 0\n M 0")
+    circuit = lestim.Circuit("X_ERROR(1) 0\n M 0")
     ref_sample = np.array([False])
     np.testing.assert_array_equal(
         circuit.compile_sampler(reference_sample=ref_sample).sample(1),
@@ -149,13 +149,13 @@ def test_reference_sample_init():
     )
     with pytest.raises(ValueError):
         circuit.compile_sampler(reference_sample=ref_sample, skip_reference_sample=True)
-    circuit = stim.Circuit("H 0\n X 1\n CNOT 0 1\n H 0 1\n MPP X0*X1")
+    circuit = lestim.Circuit("H 0\n X 1\n CNOT 0 1\n H 0 1\n MPP X0*X1")
     ref_sample = circuit.reference_sample()
     np.testing.assert_array_equal(
         circuit.compile_sampler(reference_sample=ref_sample, seed=0).sample(10),
         circuit.compile_sampler(reference_sample=None, seed=0).sample(10),
     )
-    circuit = stim.Circuit("H 0\n X 1\n CNOT 0 1\n H 0 1 2\n MPP Y1*Y2 X1*X2 Z1*Z2")
+    circuit = lestim.Circuit("H 0\n X 1\n CNOT 0 1\n H 0 1 2\n MPP Y1*Y2 X1*X2 Z1*Z2")
     ref_sample = circuit.reference_sample()
     np.testing.assert_array_equal(
         circuit.compile_sampler(reference_sample=ref_sample, seed=0).sample(11),
@@ -164,7 +164,7 @@ def test_reference_sample_init():
 
 
 def test_repr():
-    assert repr(stim.Circuit("""
+    assert repr(lestim.Circuit("""
         X 0
         M 0
     """).compile_sampler()) == """stim.CompiledMeasurementSampler(stim.Circuit('''
@@ -172,7 +172,7 @@ def test_repr():
     M 0
 '''))"""
 
-    assert repr(stim.Circuit("""
+    assert repr(lestim.Circuit("""
         X 0
         M 0
     """).compile_sampler(skip_reference_sample=True)) == """stim.CompiledMeasurementSampler(stim.Circuit('''
@@ -182,7 +182,7 @@ def test_repr():
 
 
 def test_circuit_sampler_actually_fills_array():
-    circuit = stim.Circuit('''
+    circuit = lestim.Circuit('''
        X_ERROR(1) 0
        M 0
        DETECTOR rec[-1]

--- a/src/stim/py/stim_pybind_test.py
+++ b/src/stim/py/stim_pybind_test.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 import pathlib
 
+import subprocess
+import sys
 import tempfile
 
 import doctest
@@ -21,45 +23,45 @@ import numpy as np
 import pytest
 import types
 
-import stim
+import lestim
 import re
 
 def test_version():
-    assert re.match(r"^\d\.\d+", stim.__version__)
+    assert re.match(r"^\d\.\d+", lestim.__version__)
 
 
 def test_targets():
-    t = stim.target_x(5)
-    assert isinstance(t, stim.GateTarget)
+    t = lestim.target_x(5)
+    assert isinstance(t, lestim.GateTarget)
     assert t.is_x_target and t.value == 5
     assert not t.is_y_target
 
-    t = stim.target_y(6)
-    assert isinstance(t, stim.GateTarget)
+    t = lestim.target_y(6)
+    assert isinstance(t, lestim.GateTarget)
     assert t.is_y_target and t.value == 6
 
-    t = stim.target_z(5)
-    assert isinstance(t, stim.GateTarget)
+    t = lestim.target_z(5)
+    assert isinstance(t, lestim.GateTarget)
     assert t.is_z_target and t.value == 5
 
-    t = stim.target_inv(5)
-    assert isinstance(t, stim.GateTarget)
+    t = lestim.target_inv(5)
+    assert isinstance(t, lestim.GateTarget)
     assert t.is_inverted_result_target and t.value == 5
 
-    t = stim.target_rec(-5)
-    assert isinstance(t, stim.GateTarget)
+    t = lestim.target_rec(-5)
+    assert isinstance(t, lestim.GateTarget)
     assert t.is_measurement_record_target and not t.is_inverted_result_target and t.value == -5
 
-    t = stim.target_sweep_bit(4)
-    assert isinstance(t, stim.GateTarget)
+    t = lestim.target_sweep_bit(4)
+    assert isinstance(t, lestim.GateTarget)
     assert t.is_sweep_bit_target and not t.is_inverted_result_target and t.value == 4
 
-    t = stim.target_combiner()
-    assert isinstance(t, stim.GateTarget)
+    t = lestim.target_combiner()
+    assert isinstance(t, lestim.GateTarget)
 
 
 def test_gate_data():
-    data = stim.gate_data()
+    data = lestim.gate_data()
     assert len(data) == 85
     assert data["CX"].name == "CX"
     assert data["CX"].aliases == ["CNOT", "CX", "ZCX"]
@@ -68,7 +70,7 @@ def test_gate_data():
 
 
 def test_format_data():
-    format_data = stim._UNSTABLE_raw_format_data()
+    format_data = lestim._UNSTABLE_raw_format_data()
     assert len(format_data) >= 6
 
     # Check that example code has needed imports.
@@ -124,7 +126,7 @@ def test_format_data():
 def test_main_write_to_file():
     with tempfile.TemporaryDirectory() as d:
         p = pathlib.Path(d) / 'tmp'
-        assert stim.main(command_line_args=[
+        assert lestim.main(command_line_args=[
             "gen",
             "--code=repetition_code",
             "--task=memory",
@@ -137,14 +139,14 @@ def test_main_write_to_file():
 
 
 def test_main_help(capsys):
-    assert stim.main(command_line_args=["help"]) == 0
+    assert lestim.main(command_line_args=["help"]) == 0
     captured = capsys.readouterr()
     assert captured.err == ""
     assert 'Available stim commands' in captured.out
 
 
 def test_main_redirects_stdout(capsys):
-    assert stim.main(command_line_args=[
+    assert lestim.main(command_line_args=[
         "gen",
         "--code=repetition_code",
         "--task=memory",
@@ -157,7 +159,7 @@ def test_main_redirects_stdout(capsys):
 
 
 def test_main_redirects_stderr(capsys):
-    assert stim.main(command_line_args=[
+    assert lestim.main(command_line_args=[
         "gen",
         "--code=XXXXX",
         "--task=memory",
@@ -170,132 +172,143 @@ def test_main_redirects_stderr(capsys):
 
 
 def test_target_methods_accept_gate_targets():
-    assert stim.target_inv(stim.GateTarget(5)) == stim.target_inv(5)
-    assert stim.target_inv(stim.target_inv(5)) == stim.GateTarget(5)
-    assert stim.target_inv(stim.target_x(5)) == stim.target_x(5, invert=True)
-    assert stim.target_inv(stim.target_y(5)) == stim.target_y(5, invert=True)
-    assert stim.target_inv(stim.target_z(5)) == stim.target_z(5, invert=True)
+    assert lestim.target_inv(lestim.GateTarget(5)) == lestim.target_inv(5)
+    assert lestim.target_inv(lestim.target_inv(5)) == lestim.GateTarget(5)
+    assert lestim.target_inv(lestim.target_x(5)) == lestim.target_x(5, invert=True)
+    assert lestim.target_inv(lestim.target_y(5)) == lestim.target_y(5, invert=True)
+    assert lestim.target_inv(lestim.target_z(5)) == lestim.target_z(5, invert=True)
 
-    assert stim.target_x(stim.GateTarget(5)) == stim.target_x(5)
-    assert stim.target_x(stim.target_inv(stim.GateTarget(5))) == stim.target_x(5, invert=True)
-    assert stim.target_x(stim.GateTarget(5), invert=True) == stim.target_x(5, invert=True)
-    assert stim.target_x(stim.target_inv(stim.GateTarget(5)), invert=True) == stim.target_x(5)
+    assert lestim.target_x(lestim.GateTarget(5)) == lestim.target_x(5)
+    assert lestim.target_x(lestim.target_inv(lestim.GateTarget(5))) == lestim.target_x(5, invert=True)
+    assert lestim.target_x(lestim.GateTarget(5), invert=True) == lestim.target_x(5, invert=True)
+    assert lestim.target_x(lestim.target_inv(lestim.GateTarget(5)), invert=True) == lestim.target_x(5)
 
-    assert stim.target_y(stim.GateTarget(5)) == stim.target_y(5)
-    assert stim.target_y(stim.target_inv(stim.GateTarget(5))) == stim.target_y(5, invert=True)
-    assert stim.target_y(stim.GateTarget(5), invert=True) == stim.target_y(5, invert=True)
-    assert stim.target_y(stim.target_inv(stim.GateTarget(5)), invert=True) == stim.target_y(5)
+    assert lestim.target_y(lestim.GateTarget(5)) == lestim.target_y(5)
+    assert lestim.target_y(lestim.target_inv(lestim.GateTarget(5))) == lestim.target_y(5, invert=True)
+    assert lestim.target_y(lestim.GateTarget(5), invert=True) == lestim.target_y(5, invert=True)
+    assert lestim.target_y(lestim.target_inv(lestim.GateTarget(5)), invert=True) == lestim.target_y(5)
 
-    assert stim.target_z(stim.GateTarget(5)) == stim.target_z(5)
-    assert stim.target_z(stim.target_inv(stim.GateTarget(5))) == stim.target_z(5, invert=True)
-    assert stim.target_z(stim.GateTarget(5), invert=True) == stim.target_z(5, invert=True)
-    assert stim.target_z(stim.target_inv(stim.GateTarget(5)), invert=True) == stim.target_z(5)
-
-    with pytest.raises(ValueError):
-        stim.target_inv(stim.target_sweep_bit(4))
+    assert lestim.target_z(lestim.GateTarget(5)) == lestim.target_z(5)
+    assert lestim.target_z(lestim.target_inv(lestim.GateTarget(5))) == lestim.target_z(5, invert=True)
+    assert lestim.target_z(lestim.GateTarget(5), invert=True) == lestim.target_z(5, invert=True)
+    assert lestim.target_z(lestim.target_inv(lestim.GateTarget(5)), invert=True) == lestim.target_z(5)
 
     with pytest.raises(ValueError):
-        stim.target_inv(stim.target_rec(-4))
+        lestim.target_inv(lestim.target_sweep_bit(4))
 
     with pytest.raises(ValueError):
-        stim.target_x(stim.target_sweep_bit(4))
+        lestim.target_inv(lestim.target_rec(-4))
 
     with pytest.raises(ValueError):
-        stim.target_y(stim.target_sweep_bit(4))
+        lestim.target_x(lestim.target_sweep_bit(4))
 
     with pytest.raises(ValueError):
-        stim.target_z(stim.target_sweep_bit(4))
+        lestim.target_y(lestim.target_sweep_bit(4))
+
+    with pytest.raises(ValueError):
+        lestim.target_z(lestim.target_sweep_bit(4))
 
 
 def test_target_pauli():
-    assert stim.target_pauli(2, "I") == stim.GateTarget(2)
-    assert stim.target_pauli(2, "X") == stim.target_x(2)
-    assert stim.target_pauli(2, "Y") == stim.target_y(2)
-    assert stim.target_pauli(2, "Z") == stim.target_z(2)
-    assert stim.target_pauli(5, "x") == stim.target_x(5)
-    assert stim.target_pauli(2, "y") == stim.target_y(2)
-    assert stim.target_pauli(2, "z") == stim.target_z(2)
-    assert stim.target_pauli(2, 0) == stim.GateTarget(2)
-    assert stim.target_pauli(2, 1) == stim.target_x(2)
-    assert stim.target_pauli(2, 2) == stim.target_y(2)
-    assert stim.target_pauli(2, 3) == stim.target_z(2)
-    assert stim.target_pauli(2, 3, True) == stim.target_z(2, True)
-    assert stim.target_pauli(qubit_index=2, pauli=3, invert=True) == stim.target_z(2, True)
-    assert stim.target_pauli(5, np.array([2], dtype=np.uint8)[0]) == stim.target_y(5)
-    assert stim.target_pauli(5, np.array([2], dtype=np.uint32)[0]) == stim.target_y(5)
-    assert stim.target_pauli(5, np.array([2], dtype=np.int16)[0]) == stim.target_y(5)
+    assert lestim.target_pauli(2, "I") == lestim.GateTarget(2)
+    assert lestim.target_pauli(2, "X") == lestim.target_x(2)
+    assert lestim.target_pauli(2, "Y") == lestim.target_y(2)
+    assert lestim.target_pauli(2, "Z") == lestim.target_z(2)
+    assert lestim.target_pauli(5, "x") == lestim.target_x(5)
+    assert lestim.target_pauli(2, "y") == lestim.target_y(2)
+    assert lestim.target_pauli(2, "z") == lestim.target_z(2)
+    assert lestim.target_pauli(2, 0) == lestim.GateTarget(2)
+    assert lestim.target_pauli(2, 1) == lestim.target_x(2)
+    assert lestim.target_pauli(2, 2) == lestim.target_y(2)
+    assert lestim.target_pauli(2, 3) == lestim.target_z(2)
+    assert lestim.target_pauli(2, 3, True) == lestim.target_z(2, True)
+    assert lestim.target_pauli(qubit_index=2, pauli=3, invert=True) == lestim.target_z(2, True)
+    assert lestim.target_pauli(5, np.array([2], dtype=np.uint8)[0]) == lestim.target_y(5)
+    assert lestim.target_pauli(5, np.array([2], dtype=np.uint32)[0]) == lestim.target_y(5)
+    assert lestim.target_pauli(5, np.array([2], dtype=np.int16)[0]) == lestim.target_y(5)
 
     with pytest.raises(ValueError, match="too large"):
-        stim.target_pauli(2**31, 'X')
+        lestim.target_pauli(2**31, 'X')
     with pytest.raises(ValueError, match="Expected pauli"):
-        stim.target_pauli(5, 'F')
+        lestim.target_pauli(5, 'F')
     with pytest.raises(ValueError, match="Expected pauli"):
-        stim.target_pauli(5, np.array([257], dtype=np.uint32)[0])
+        lestim.target_pauli(5, np.array([257], dtype=np.uint32)[0])
 
 
 def test_target_combined_paulis():
-    assert stim.target_combined_paulis(stim.PauliString("XYZ")) == [
-        stim.target_x(0),
-        stim.target_combiner(),
-        stim.target_y(1),
-        stim.target_combiner(),
-        stim.target_z(2),
+    assert lestim.target_combined_paulis(lestim.PauliString("XYZ")) == [
+        lestim.target_x(0),
+        lestim.target_combiner(),
+        lestim.target_y(1),
+        lestim.target_combiner(),
+        lestim.target_z(2),
     ]
 
-    assert stim.target_combined_paulis(stim.PauliString("X"), True) == [
-        stim.target_x(0, True),
+    assert lestim.target_combined_paulis(lestim.PauliString("X"), True) == [
+        lestim.target_x(0, True),
     ]
 
-    assert stim.target_combined_paulis(stim.PauliString("-XYIZ")) == [
-        stim.target_x(0, invert=True),
-        stim.target_combiner(),
-        stim.target_y(1),
-        stim.target_combiner(),
-        stim.target_z(3),
+    assert lestim.target_combined_paulis(lestim.PauliString("-XYIZ")) == [
+        lestim.target_x(0, invert=True),
+        lestim.target_combiner(),
+        lestim.target_y(1),
+        lestim.target_combiner(),
+        lestim.target_z(3),
     ]
 
-    assert stim.target_combined_paulis(stim.PauliString("-XYIZ"), True) == [
-        stim.target_x(0),
-        stim.target_combiner(),
-        stim.target_y(1),
-        stim.target_combiner(),
-        stim.target_z(3),
+    assert lestim.target_combined_paulis(lestim.PauliString("-XYIZ"), True) == [
+        lestim.target_x(0),
+        lestim.target_combiner(),
+        lestim.target_y(1),
+        lestim.target_combiner(),
+        lestim.target_z(3),
     ]
 
-    assert stim.target_combined_paulis([stim.target_x(5), stim.target_z(9)]) == [
-        stim.target_x(5),
-        stim.target_combiner(),
-        stim.target_z(9),
+    assert lestim.target_combined_paulis([lestim.target_x(5), lestim.target_z(9)]) == [
+        lestim.target_x(5),
+        lestim.target_combiner(),
+        lestim.target_z(9),
     ]
 
-    assert stim.target_combined_paulis([stim.target_x(5, True), stim.target_z(9)]) == [
-        stim.target_x(5, True),
-        stim.target_combiner(),
-        stim.target_z(9),
+    assert lestim.target_combined_paulis([lestim.target_x(5, True), lestim.target_z(9)]) == [
+        lestim.target_x(5, True),
+        lestim.target_combiner(),
+        lestim.target_z(9),
     ]
-    assert stim.target_combined_paulis([stim.target_x(5), stim.target_z(9, True)]) == [
-        stim.target_x(5, True),
-        stim.target_combiner(),
-        stim.target_z(9),
+    assert lestim.target_combined_paulis([lestim.target_x(5), lestim.target_z(9, True)]) == [
+        lestim.target_x(5, True),
+        lestim.target_combiner(),
+        lestim.target_z(9),
     ]
-    assert stim.target_combined_paulis([stim.target_x(5), stim.target_z(9)], True) == [
-        stim.target_x(5, True),
-        stim.target_combiner(),
-        stim.target_z(9),
+    assert lestim.target_combined_paulis([lestim.target_x(5), lestim.target_z(9)], True) == [
+        lestim.target_x(5, True),
+        lestim.target_combiner(),
+        lestim.target_z(9),
     ]
-    assert stim.target_combined_paulis([stim.target_y(4)]) == [
-        stim.target_y(4),
+    assert lestim.target_combined_paulis([lestim.target_y(4)]) == [
+        lestim.target_y(4),
     ]
 
     with pytest.raises(ValueError, match="Expected a pauli string"):
-        stim.target_combined_paulis([stim.target_rec(-2)])
+        lestim.target_combined_paulis([lestim.target_rec(-2)])
     with pytest.raises(ValueError, match="Expected a pauli string"):
-        stim.target_combined_paulis([object()])
+        lestim.target_combined_paulis([object()])
     with pytest.raises(ValueError, match="Identity pauli product"):
-        stim.target_combined_paulis([])
+        lestim.target_combined_paulis([])
     with pytest.raises(ValueError, match="Identity pauli product"):
-        stim.target_combined_paulis(stim.PauliString(0))
+        lestim.target_combined_paulis(lestim.PauliString(0))
     with pytest.raises(ValueError, match="Identity pauli product"):
-        stim.target_combined_paulis(stim.PauliString(10))
+        lestim.target_combined_paulis(lestim.PauliString(10))
     with pytest.raises(ValueError, match="Imaginary"):
-        stim.target_combined_paulis(stim.PauliString("iX"))
+        lestim.target_combined_paulis(lestim.PauliString("iX"))
+
+
+def test_lestim_stim_compatibility():
+    """Show that lestim can be imported after stim without their python bindings conflicting"""
+    code = "import stim, lestim"
+    subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=True,
+    )

--- a/src/stim/simulators/dem_sampler_pybind_test.py
+++ b/src/stim/simulators/dem_sampler_pybind_test.py
@@ -1,13 +1,13 @@
 import numpy as np
 import pathlib
 import pytest
-import stim
+import lestim
 import tempfile
 
 
 @pytest.mark.parametrize("bit_packed", [False, True])
 def test_dem_sampler_sample(bit_packed: bool):
-    noisy_dem = stim.DetectorErrorModel("""
+    noisy_dem = lestim.DetectorErrorModel("""
         error(0.125) D0
         error(0.25) D1
     """)
@@ -19,7 +19,7 @@ def test_dem_sampler_sample(bit_packed: bool):
 
 
 def test_dem_sampler_sampler_write():
-    dem = stim.DetectorErrorModel('''
+    dem = lestim.DetectorErrorModel('''
        error(0) D0
        error(0) D1
        error(0) D0
@@ -45,7 +45,7 @@ def test_dem_sampler_sampler_write():
         with open(d / 'err.hits') as f:
             assert f.read() == "3\n"
 
-        sampler = stim.DetectorErrorModel('''
+        sampler = lestim.DetectorErrorModel('''
            error(1) D0  # this should be overridden by the replay.
            error(1) D1
            error(1) D0
@@ -74,7 +74,7 @@ def test_dem_sampler_sampler_write():
 
 
 def test_dem_sampler_actually_fills_obs_array():
-    dem = stim.DetectorErrorModel('''
+    dem = lestim.DetectorErrorModel('''
        error(1) L0
     ''')
     sampler = dem.compile_sampler()

--- a/src/stim/simulators/matched_error_pybind_test.py
+++ b/src/stim/simulators/matched_error_pybind_test.py
@@ -1,8 +1,8 @@
-import stim
+import lestim
 
 
 def test_CircuitErrorLocationStackFrame():
-    v1 = stim.CircuitErrorLocationStackFrame(
+    v1 = lestim.CircuitErrorLocationStackFrame(
         instruction_offset=1,
         iteration_index=2,
         instruction_repetitions_arg=3,
@@ -11,7 +11,7 @@ def test_CircuitErrorLocationStackFrame():
     assert v1.iteration_index == 2
     assert v1.instruction_repetitions_arg == 3
 
-    v2 = stim.CircuitErrorLocationStackFrame(
+    v2 = lestim.CircuitErrorLocationStackFrame(
         instruction_offset=2,
         iteration_index=3,
         instruction_repetitions_arg=5,
@@ -19,86 +19,86 @@ def test_CircuitErrorLocationStackFrame():
     assert v1 != v2
     assert v1 == v1
     assert len({v1, v1, v2}) == 2  # Check hashable.
-    assert eval(repr(v1), {"stim": stim}) == v1
-    assert eval(repr(v2), {"stim": stim}) == v2
+    assert eval(repr(v1), {"stim": lestim}) == v1
+    assert eval(repr(v2), {"stim": lestim}) == v2
     assert str(v1) == repr(v1)
 
 
 def test_GateTargetWithCoords():
-    v1 = stim.GateTargetWithCoords(
-        gate_target=stim.target_x(5),
+    v1 = lestim.GateTargetWithCoords(
+        gate_target=lestim.target_x(5),
         coords=[1, 2, 3],
     )
-    assert v1.gate_target == stim.GateTarget(stim.target_x(5))
+    assert v1.gate_target == lestim.GateTarget(lestim.target_x(5))
     assert v1.coords == [1, 2, 3]
-    v2 = stim.GateTargetWithCoords(
-        gate_target=stim.GateTarget(4),
+    v2 = lestim.GateTargetWithCoords(
+        gate_target=lestim.GateTarget(4),
         coords=[1, 2],
     )
     assert v1 != v2
     assert v1 == v1
     assert len({v1, v1, v2}) == 2  # Check hashable.
-    assert eval(repr(v1), {"stim": stim}) == v1
-    assert eval(repr(v2), {"stim": stim}) == v2
+    assert eval(repr(v1), {"stim": lestim}) == v1
+    assert eval(repr(v2), {"stim": lestim}) == v2
     assert str(v1) == 'X5[coords 1,2,3]'
 
 
 def test_DemTargetWithCoords():
-    v1 = stim.DemTargetWithCoords(
-        dem_target=stim.DemTarget.relative_detector_id(5),
+    v1 = lestim.DemTargetWithCoords(
+        dem_target=lestim.DemTarget.relative_detector_id(5),
         coords=[1, 2, 3],
     )
-    assert v1.dem_target == stim.DemTarget.relative_detector_id(5)
+    assert v1.dem_target == lestim.DemTarget.relative_detector_id(5)
     assert v1.coords == [1, 2, 3]
-    v2 = stim.DemTargetWithCoords(
-        dem_target=stim.DemTarget.logical_observable_id(3),
+    v2 = lestim.DemTargetWithCoords(
+        dem_target=lestim.DemTarget.logical_observable_id(3),
         coords=(),
     )
     assert v1 != v2
     assert v1 == v1
     assert len({v1, v1, v2}) == 2  # Check hashable.
-    assert eval(repr(v1), {"stim": stim}) == v1
-    assert eval(repr(v2), {"stim": stim}) == v2
+    assert eval(repr(v1), {"stim": lestim}) == v1
+    assert eval(repr(v2), {"stim": lestim}) == v2
     assert str(v1) == 'D5[coords 1,2,3]'
 
 
 def test_FlippedMeasurement():
-    v1 = stim.FlippedMeasurement(
+    v1 = lestim.FlippedMeasurement(
         record_index=5,
         observable=[
-            stim.GateTargetWithCoords(
-                gate_target=stim.target_x(5),
+            lestim.GateTargetWithCoords(
+                gate_target=lestim.target_x(5),
                 coords=[1, 2, 3]),
         ],
     )
     assert v1.record_index == 5
     assert v1.observable == [
-        stim.GateTargetWithCoords(
-            gate_target=stim.target_x(5),
+        lestim.GateTargetWithCoords(
+            gate_target=lestim.target_x(5),
             coords=[1, 2, 3]),
     ]
-    v2 = stim.FlippedMeasurement(
+    v2 = lestim.FlippedMeasurement(
         record_index=5,
         observable=[],
     )
     assert v1 != v2
     assert v1 == v1
     assert len({v1, v1, v2}) == 2  # Check hashable.
-    assert eval(repr(v1), {"stim": stim}) == v1
-    assert eval(repr(v2), {"stim": stim}) == v2
+    assert eval(repr(v1), {"stim": lestim}) == v1
+    assert eval(repr(v2), {"stim": lestim}) == v2
     assert str(v1) == repr(v1)
 
 
 def test_CircuitTargetsInsideInstruction():
-    v1 = stim.CircuitTargetsInsideInstruction(
+    v1 = lestim.CircuitTargetsInsideInstruction(
         gate="X_ERROR",
         args=[0.25],
         target_range_start=2,
         target_range_end=5,
         targets_in_range=[
-            stim.GateTargetWithCoords(gate_target=5, coords=[1, 2]),
-            stim.GateTargetWithCoords(gate_target=6, coords=[1, 3]),
-            stim.GateTargetWithCoords(gate_target=7, coords=[]),
+            lestim.GateTargetWithCoords(gate_target=5, coords=[1, 2]),
+            lestim.GateTargetWithCoords(gate_target=6, coords=[1, 3]),
+            lestim.GateTargetWithCoords(gate_target=7, coords=[]),
         ],
     )
     assert v1.gate == "X_ERROR"
@@ -106,11 +106,11 @@ def test_CircuitTargetsInsideInstruction():
     assert v1.target_range_start == 2
     assert v1.target_range_end == 5
     assert v1.targets_in_range == [
-        stim.GateTargetWithCoords(gate_target=5, coords=[1, 2]),
-        stim.GateTargetWithCoords(gate_target=6, coords=[1, 3]),
-        stim.GateTargetWithCoords(gate_target=7, coords=[]),
+        lestim.GateTargetWithCoords(gate_target=5, coords=[1, 2]),
+        lestim.GateTargetWithCoords(gate_target=6, coords=[1, 3]),
+        lestim.GateTargetWithCoords(gate_target=7, coords=[]),
     ]
-    v2 = stim.CircuitTargetsInsideInstruction(
+    v2 = lestim.CircuitTargetsInsideInstruction(
         gate="Z_ERROR",
         args=[0.125],
         target_range_start=3,
@@ -120,44 +120,44 @@ def test_CircuitTargetsInsideInstruction():
     assert v1 != v2
     assert v1 == v1
     assert len({v1, v1, v2}) == 2  # Check hashable.
-    assert eval(repr(v1), {"stim": stim}) == v1
-    assert eval(repr(v2), {"stim": stim}) == v2
+    assert eval(repr(v1), {"stim": lestim}) == v1
+    assert eval(repr(v2), {"stim": lestim}) == v2
     assert str(v1) == "X_ERROR(0.25) 5[coords 1,2] 6[coords 1,3] 7"
 
 
 def test_CircuitErrorLocation():
-    m = stim.FlippedMeasurement(
+    m = lestim.FlippedMeasurement(
         record_index=5,
         observable=[
-            stim.GateTargetWithCoords(
-                gate_target=stim.target_x(5),
+            lestim.GateTargetWithCoords(
+                gate_target=lestim.target_x(5),
                 coords=[1, 2, 3]),
         ],
     )
     p = [
-        stim.GateTargetWithCoords(
-            gate_target=stim.target_y(6),
+        lestim.GateTargetWithCoords(
+            gate_target=lestim.target_y(6),
             coords=[1, 2, 3]),
     ]
-    t = stim.CircuitTargetsInsideInstruction(
+    t = lestim.CircuitTargetsInsideInstruction(
         gate="X_ERROR",
         args=[0.25],
         target_range_start=2,
         target_range_end=5,
         targets_in_range=[
-            stim.GateTargetWithCoords(gate_target=5, coords=[1, 2]),
-            stim.GateTargetWithCoords(gate_target=6, coords=[1, 3]),
-            stim.GateTargetWithCoords(gate_target=7, coords=[]),
+            lestim.GateTargetWithCoords(gate_target=5, coords=[1, 2]),
+            lestim.GateTargetWithCoords(gate_target=6, coords=[1, 3]),
+            lestim.GateTargetWithCoords(gate_target=7, coords=[]),
         ],
     )
     s = [
-        stim.CircuitErrorLocationStackFrame(
+        lestim.CircuitErrorLocationStackFrame(
             instruction_offset=1,
             iteration_index=2,
             instruction_repetitions_arg=3,
         )
     ] * 2
-    v1 = stim.CircuitErrorLocation(
+    v1 = lestim.CircuitErrorLocation(
         tick_offset=5,
         flipped_pauli_product=p,
         flipped_measurement=m,
@@ -169,7 +169,7 @@ def test_CircuitErrorLocation():
     assert v1.flipped_measurement == m
     assert v1.instruction_targets == t
     assert v1.stack_frames == s
-    v2 = stim.CircuitErrorLocation(
+    v2 = lestim.CircuitErrorLocation(
         tick_offset=5,
         flipped_pauli_product=[],
         flipped_measurement=None,
@@ -180,8 +180,8 @@ def test_CircuitErrorLocation():
     assert v1 != v2
     assert v1 == v1
     assert len({v1, v1, v2}) == 2  # Check hashable.
-    assert eval(repr(v1), {"stim": stim}) == v1
-    assert eval(repr(v2), {"stim": stim}) == v2
+    assert eval(repr(v1), {"stim": lestim}) == v1
+    assert eval(repr(v2), {"stim": lestim}) == v2
     assert str(v1) == """CircuitErrorLocation {
     flipped_pauli_product: Y6[coords 1,2,3]
     flipped_measurement.measurement_record_index: 5
@@ -197,65 +197,65 @@ def test_CircuitErrorLocation():
 
 
 def test_MatchedError():
-    m = stim.FlippedMeasurement(
+    m = lestim.FlippedMeasurement(
         record_index=5,
         observable=[
-            stim.GateTargetWithCoords(
-                gate_target=stim.target_x(5),
+            lestim.GateTargetWithCoords(
+                gate_target=lestim.target_x(5),
                 coords=[1, 2, 3]),
         ],
     )
     p = [
-        stim.GateTargetWithCoords(
-            gate_target=stim.target_y(6),
+        lestim.GateTargetWithCoords(
+            gate_target=lestim.target_y(6),
             coords=[1, 2, 3]),
     ]
-    t = stim.CircuitTargetsInsideInstruction(
+    t = lestim.CircuitTargetsInsideInstruction(
         gate="X_ERROR",
         args=[0.25],
         target_range_start=2,
         target_range_end=5,
         targets_in_range=[
-            stim.GateTargetWithCoords(gate_target=5, coords=[1, 2]),
-            stim.GateTargetWithCoords(gate_target=6, coords=[1, 3]),
-            stim.GateTargetWithCoords(gate_target=7, coords=[]),
+            lestim.GateTargetWithCoords(gate_target=5, coords=[1, 2]),
+            lestim.GateTargetWithCoords(gate_target=6, coords=[1, 3]),
+            lestim.GateTargetWithCoords(gate_target=7, coords=[]),
         ],
     )
     s = [
-        stim.CircuitErrorLocationStackFrame(
+        lestim.CircuitErrorLocationStackFrame(
             instruction_offset=1,
             iteration_index=2,
             instruction_repetitions_arg=3,
         )
     ] * 2
-    e = stim.CircuitErrorLocation(
+    e = lestim.CircuitErrorLocation(
         tick_offset=5,
         flipped_pauli_product=p,
         flipped_measurement=m,
         instruction_targets=t,
         stack_frames=s,
     )
-    v1 = stim.ExplainedError(
-        dem_error_terms=[stim.DemTargetWithCoords(
-            dem_target=stim.DemTarget.relative_detector_id(5),
+    v1 = lestim.ExplainedError(
+        dem_error_terms=[lestim.DemTargetWithCoords(
+            dem_target=lestim.DemTarget.relative_detector_id(5),
             coords=[1, 2, 3],
         )],
         circuit_error_locations=[e],
     )
-    assert v1.dem_error_terms == [stim.DemTargetWithCoords(
-        dem_target=stim.DemTarget.relative_detector_id(5),
+    assert v1.dem_error_terms == [lestim.DemTargetWithCoords(
+        dem_target=lestim.DemTarget.relative_detector_id(5),
         coords=[1, 2, 3],
     )]
     assert v1.circuit_error_locations == [e]
-    v2 = stim.ExplainedError(
+    v2 = lestim.ExplainedError(
         dem_error_terms=[],
         circuit_error_locations=[],
     )
     assert v1 != v2
     assert v1 == v1
     assert len({v1, v1, v2}) == 2  # Check hashable.
-    assert eval(repr(v1), {"stim": stim}) == v1
-    assert eval(repr(v2), {"stim": stim}) == v2
+    assert eval(repr(v1), {"stim": lestim}) == v1
+    assert eval(repr(v2), {"stim": lestim}) == v2
     assert str(v1) == """ExplainedError {
     dem_error_terms: D5[coords 1,2,3]
     CircuitErrorLocation {

--- a/src/stim/simulators/measurements_to_detection_events_test.py
+++ b/src/stim/simulators/measurements_to_detection_events_test.py
@@ -16,11 +16,11 @@ import tempfile
 import numpy as np
 import pytest
 import pickle
-import stim
+import lestim
 
 
 def test_convert_file_without_sweep_bits():
-    converter = stim.Circuit('''
+    converter = lestim.Circuit('''
         X_ERROR(0.1) 0
         X 0
         CNOT sweep[0] 0
@@ -86,7 +86,7 @@ def test_convert_file_without_sweep_bits():
 
 
 def test_convert():
-    converter = stim.Circuit('''
+    converter = lestim.Circuit('''
        X_ERROR(0.1) 0
        X 0
        CNOT sweep[0] 0
@@ -122,7 +122,7 @@ def test_convert():
 
 
 def test_convert_bit_packed():
-    converter = stim.Circuit('''
+    converter = lestim.Circuit('''
        REPEAT 100 {
            X_ERROR(0.1) 0
            X 0
@@ -166,7 +166,7 @@ def test_convert_bit_packed():
 
 
 def test_convert_bit_packed_swept():
-    converter = stim.Circuit('''
+    converter = lestim.Circuit('''
        REPEAT 100 {
            CNOT sweep[0] 0
            X_ERROR(0.1) 0
@@ -207,7 +207,7 @@ def test_convert_bit_packed_swept():
 
 
 def test_convert_bit_packed_separate_observables():
-    converter = stim.Circuit('''
+    converter = lestim.Circuit('''
        REPEAT 100 {
            X_ERROR(0.1) 0
            X 0
@@ -250,7 +250,7 @@ def test_convert_bit_packed_separate_observables():
 
 
 def test_noiseless_conversion():
-    converter = stim.Circuit('''
+    converter = lestim.Circuit('''
        MR 0
        DETECTOR rec[-1]
        X 0
@@ -275,7 +275,7 @@ def test_noiseless_conversion():
 
 
 def test_needs_append_or_separate():
-    converter = stim.Circuit().compile_m2d_converter()
+    converter = lestim.Circuit().compile_m2d_converter()
     ms = np.zeros(shape=(50, 0), dtype=np.bool_)
     with pytest.raises(ValueError, match="explicitly specify either separate"):
         converter.convert(measurements=ms)
@@ -289,7 +289,7 @@ def test_needs_append_or_separate():
 
 
 def test_anticommuting_pieces_combining_into_deterministic_observable():
-    c = stim.Circuit('''
+    c = lestim.Circuit('''
         MX 0
         OBSERVABLE_INCLUDE(0) rec[-1]
         MX 0
@@ -301,7 +301,7 @@ def test_anticommuting_pieces_combining_into_deterministic_observable():
 
 
 def test_converter_pickle():
-    converter = stim.Circuit('''
+    converter = lestim.Circuit('''
        X_ERROR(0.1) 0
        X 0
        CNOT sweep[0] 0

--- a/src/stim/simulators/tableau_simulator_pybind_test.py
+++ b/src/stim/simulators/tableau_simulator_pybind_test.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import pytest
-import stim
+import lestim
 import numpy as np
 
 
 def test_basic():
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
     assert s.measure(0) is False
     assert s.measure(0) is False
     s.x(0)
@@ -33,30 +33,30 @@ def test_basic():
 
 
 def test_access_tableau():
-    s = stim.TableauSimulator()
-    assert s.current_inverse_tableau() == stim.Tableau(0)
+    s = lestim.TableauSimulator()
+    assert s.current_inverse_tableau() == lestim.Tableau(0)
 
     s.h(0)
-    assert s.current_inverse_tableau() == stim.Tableau.from_named_gate("H")
+    assert s.current_inverse_tableau() == lestim.Tableau.from_named_gate("H")
 
     s.h(0)
-    assert s.current_inverse_tableau() == stim.Tableau(1)
+    assert s.current_inverse_tableau() == lestim.Tableau(1)
 
     s.h(1)
     s.h(1)
-    assert s.current_inverse_tableau() == stim.Tableau(2)
+    assert s.current_inverse_tableau() == lestim.Tableau(2)
 
     s.h(2)
-    assert s.current_inverse_tableau() == stim.Tableau.from_conjugated_generators(
+    assert s.current_inverse_tableau() == lestim.Tableau.from_conjugated_generators(
         xs=[
-            stim.PauliString("X__"),
-            stim.PauliString("_X_"),
-            stim.PauliString("__Z"),
+            lestim.PauliString("X__"),
+            lestim.PauliString("_X_"),
+            lestim.PauliString("__Z"),
         ],
         zs=[
-            stim.PauliString("Z__"),
-            stim.PauliString("_Z_"),
-            stim.PauliString("__X"),
+            lestim.PauliString("Z__"),
+            lestim.PauliString("_Z_"),
+            lestim.PauliString("__X"),
         ],
     )
 
@@ -88,44 +88,44 @@ def test_access_tableau():
     "cz",
 ])
 def test_gates_present(name: str):
-    t = stim.Tableau.from_named_gate(name)
+    t = lestim.Tableau.from_named_gate(name)
     n = len(t)
-    s1 = stim.TableauSimulator()
-    s2 = stim.TableauSimulator()
+    s1 = lestim.TableauSimulator()
+    s2 = lestim.TableauSimulator()
     for k in range(n):
         s1.h(k)
         s2.h(k)
         s1.cnot(k, k + n)
         s2.cnot(k, k + n)
     getattr(s1, name)(*range(n))
-    s2.do(stim.Circuit(f"{name} " + " ".join(str(e) for e in range(n))))
+    s2.do(lestim.Circuit(f"{name} " + " ".join(str(e) for e in range(n))))
     assert s1.current_inverse_tableau() == s2.current_inverse_tableau()
 
 
 def test_do():
-    s = stim.TableauSimulator()
-    s.do(stim.Circuit("""
+    s = lestim.TableauSimulator()
+    s.do(lestim.Circuit("""
         S 0
     """))
-    assert s.current_inverse_tableau() == stim.Tableau.from_named_gate("S_DAG")
+    assert s.current_inverse_tableau() == lestim.Tableau.from_named_gate("S_DAG")
 
 
 def test_peek_bloch():
-    s = stim.TableauSimulator()
-    assert s.peek_bloch(0) == stim.PauliString("+Z")
+    s = lestim.TableauSimulator()
+    assert s.peek_bloch(0) == lestim.PauliString("+Z")
     s.x(0)
-    assert s.peek_bloch(0) == stim.PauliString("-Z")
+    assert s.peek_bloch(0) == lestim.PauliString("-Z")
     s.h(0)
-    assert s.peek_bloch(0) == stim.PauliString("-X")
+    assert s.peek_bloch(0) == lestim.PauliString("-X")
     s.sqrt_x(1)
-    assert s.peek_bloch(1) == stim.PauliString("-Y")
+    assert s.peek_bloch(1) == lestim.PauliString("-Y")
     s.cz(0, 1)
-    assert s.peek_bloch(0) == stim.PauliString("+I")
-    assert s.peek_bloch(1) == stim.PauliString("+I")
+    assert s.peek_bloch(0) == lestim.PauliString("+I")
+    assert s.peek_bloch(1) == lestim.PauliString("+I")
 
 
 def test_copy():
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
     s.h(0)
     s2 = s.copy()
     assert s.current_inverse_tableau() == s2.current_inverse_tableau()
@@ -133,11 +133,11 @@ def test_copy():
 
 
 def test_paulis():
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
     s.h(*range(0, 22, 2))
     s.cnot(*range(22))
 
-    s.do(stim.PauliString("ZZZ_YYY_XXX"))
+    s.do(lestim.PauliString("ZZZ_YYY_XXX"))
     s.z(0, 1, 2)
     s.y(4, 5, 6)
     s.x(8, 9, 10)
@@ -146,15 +146,15 @@ def test_paulis():
     s.h(*range(0, 22, 2))
     assert s.measure_many(*range(22)) == [False] * 22
 
-    s = stim.TableauSimulator()
-    s.do(stim.PauliString("Z" * 500))
+    s = lestim.TableauSimulator()
+    s.do(lestim.PauliString("Z" * 500))
     assert s.measure_many(*range(500)) == [False] * 500
-    s.do(stim.PauliString("X" * 500))
+    s.do(lestim.PauliString("X" * 500))
     assert s.measure_many(*range(500)) == [True] * 500
 
 
 def test_measure_kickback():
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
     assert s.measure_kickback(0) == (False, None)
     assert s.measure_kickback(0) == (False, None)
     assert s.current_measurement_record() == [False, False]
@@ -162,29 +162,29 @@ def test_measure_kickback():
     s.h(0)
     v = s.measure_kickback(0)
     assert isinstance(v[0], bool)
-    assert v[1] == stim.PauliString("X")
+    assert v[1] == lestim.PauliString("X")
     assert s.measure_kickback(0) == (v[0], None)
     assert s.current_measurement_record() == [False, False, v[0], v[0]]
 
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
     s.h(0)
     s.cnot(0, 1)
     v = s.measure_kickback(0)
     assert isinstance(v[0], bool)
-    assert v[1] == stim.PauliString("XX")
+    assert v[1] == lestim.PauliString("XX")
     assert s.measure_kickback(0) == (v[0], None)
 
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
     s.h(0)
     s.cnot(0, 1)
     v = s.measure_kickback(1)
     assert isinstance(v[0], bool)
-    assert v[1] == stim.PauliString("XX")
+    assert v[1] == lestim.PauliString("XX")
     assert s.measure_kickback(0) == (v[0], None)
 
 
 def test_post_select_using_measure_kickback():
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
 
     def pseudo_post_select(qubit, desired_result):
         m, kick = s.measure_kickback(qubit)
@@ -201,8 +201,8 @@ def test_post_select_using_measure_kickback():
 
 
 def test_measure_kickback_random_branches():
-    s = stim.TableauSimulator()
-    s.set_inverse_tableau(stim.Tableau.random(8))
+    s = lestim.TableauSimulator()
+    s.set_inverse_tableau(lestim.Tableau.random(8))
 
     r = s.peek_bloch(4)
     if r[0] == 3:  # +-Z?
@@ -222,7 +222,7 @@ def test_measure_kickback_random_branches():
     assert post_false is not None and post_true is not None
 
     result, kick = s.measure_kickback(4)
-    assert isinstance(kick, stim.PauliString) and len(kick) == 8
+    assert isinstance(kick, lestim.PauliString) and len(kick) == 8
     if result:
         s.do(kick)
     assert s.canonical_stabilizers() == post_false.canonical_stabilizers()
@@ -231,7 +231,7 @@ def test_measure_kickback_random_branches():
 
 
 def test_set_num_qubits():
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
     s.h(0)
     s.cnot(0, 1)
     s.cnot(0, 2)
@@ -240,52 +240,52 @@ def test_set_num_qubits():
     s.set_num_qubits(8)
     s.set_num_qubits(4)
     assert s.current_inverse_tableau() == t
-    assert s.peek_bloch(0) == stim.PauliString("_")
+    assert s.peek_bloch(0) == lestim.PauliString("_")
     s.set_num_qubits(8)
     s.set_num_qubits(4)
     s.cnot(0, 4)
     s.set_num_qubits(4)
-    assert s.peek_bloch(0) in [stim.PauliString("+Z"), stim.PauliString("-Z")]
+    assert s.peek_bloch(0) in [lestim.PauliString("+Z"), lestim.PauliString("-Z")]
 
 
 def test_canonical_stabilizers():
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
     s.h(0)
     s.h(1)
     s.h(2)
     s.cz(0, 1)
     s.cz(1, 2)
     assert s.canonical_stabilizers() == [
-        stim.PauliString("+X_X"),
-        stim.PauliString("+ZXZ"),
-        stim.PauliString("+_ZX"),
+        lestim.PauliString("+X_X"),
+        lestim.PauliString("+ZXZ"),
+        lestim.PauliString("+_ZX"),
     ]
     s.s(1)
     assert s.canonical_stabilizers() == [
-        stim.PauliString("+X_X"),
-        stim.PauliString("-ZXY"),
-        stim.PauliString("+_ZX"),
+        lestim.PauliString("+X_X"),
+        lestim.PauliString("-ZXY"),
+        lestim.PauliString("+_ZX"),
     ]
 
 
 def test_classical_control_cnot():
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
 
     with pytest.raises(IndexError, match="beginning of time"):
-        s.cnot(stim.target_rec(-1), 0)
+        s.cnot(lestim.target_rec(-1), 0)
 
     assert not s.measure(1)
-    s.cnot(stim.target_rec(-1), 0)
+    s.cnot(lestim.target_rec(-1), 0)
     assert not s.measure(0)
 
     s.x(1)
     assert s.measure(1)
-    s.cnot(stim.target_rec(-1), 0)
+    s.cnot(lestim.target_rec(-1), 0)
     assert s.measure(0)
 
 
 def test_collision():
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
     with pytest.raises(ValueError, match="same target"):
         s.cnot(0, 0)
     with pytest.raises(ValueError, match="same target"):
@@ -317,7 +317,7 @@ def test_is_parallel_state_vector():
 
 
 def test_to_state_vector():
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
     assert is_parallel_state_vector(s.state_vector(), [1])
     s.set_num_qubits(1)
     assert is_parallel_state_vector(s.state_vector(), [1, 0])
@@ -338,7 +338,7 @@ def test_to_state_vector():
     assert v[0, 1, 0] == 0
     assert v[0, 0, 1] == 0
 
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
     s.set_num_qubits(3)
     s.sqrt_x(2)
     np.testing.assert_allclose(
@@ -363,57 +363,57 @@ def test_to_state_vector():
 
 
 def test_peek_observable_expectation():
-    s = stim.TableauSimulator()
-    s.do(stim.Circuit('''
+    s = lestim.TableauSimulator()
+    s.do(lestim.Circuit('''
         H 0
         CNOT 0 1 0 2
         X 0
     '''))
 
-    assert s.peek_observable_expectation(stim.PauliString("ZZ_")) == -1
-    assert s.peek_observable_expectation(stim.PauliString("_ZZ")) == 1
-    assert s.peek_observable_expectation(stim.PauliString("Z_Z")) == -1
-    assert s.peek_observable_expectation(stim.PauliString("XXX")) == 1
-    assert s.peek_observable_expectation(stim.PauliString("-XXX")) == -1
-    assert s.peek_observable_expectation(stim.PauliString("YYX")) == +1
-    assert s.peek_observable_expectation(stim.PauliString("XYY")) == -1
+    assert s.peek_observable_expectation(lestim.PauliString("ZZ_")) == -1
+    assert s.peek_observable_expectation(lestim.PauliString("_ZZ")) == 1
+    assert s.peek_observable_expectation(lestim.PauliString("Z_Z")) == -1
+    assert s.peek_observable_expectation(lestim.PauliString("XXX")) == 1
+    assert s.peek_observable_expectation(lestim.PauliString("-XXX")) == -1
+    assert s.peek_observable_expectation(lestim.PauliString("YYX")) == +1
+    assert s.peek_observable_expectation(lestim.PauliString("XYY")) == -1
 
-    assert s.peek_observable_expectation(stim.PauliString("")) == 1
-    assert s.peek_observable_expectation(stim.PauliString("-I")) == -1
-    assert s.peek_observable_expectation(stim.PauliString("_____")) == 1
-    assert s.peek_observable_expectation(stim.PauliString("XXXZZZZZ")) == 1
-    assert s.peek_observable_expectation(stim.PauliString("XXXZZZZX")) == 0
+    assert s.peek_observable_expectation(lestim.PauliString("")) == 1
+    assert s.peek_observable_expectation(lestim.PauliString("-I")) == -1
+    assert s.peek_observable_expectation(lestim.PauliString("_____")) == 1
+    assert s.peek_observable_expectation(lestim.PauliString("XXXZZZZZ")) == 1
+    assert s.peek_observable_expectation(lestim.PauliString("XXXZZZZX")) == 0
 
     with pytest.raises(ValueError, match="imaginary sign"):
-        s.peek_observable_expectation(stim.PauliString("iZZ"))
+        s.peek_observable_expectation(lestim.PauliString("iZZ"))
     with pytest.raises(ValueError, match="imaginary sign"):
-        s.peek_observable_expectation(stim.PauliString("-iZZ"))
+        s.peek_observable_expectation(lestim.PauliString("-iZZ"))
 
 
 def test_postselect():
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
     s.h(0)
     s.cnot(0, 1)
     s.postselect_x(0, desired_value=False)
-    assert s.peek_bloch(0) == stim.PauliString("+X")
-    assert s.peek_bloch(1) == stim.PauliString("+X")
+    assert s.peek_bloch(0) == lestim.PauliString("+X")
+    assert s.peek_bloch(1) == lestim.PauliString("+X")
 
     s.postselect_y([2, 3, 4], desired_value=False)
-    assert s.peek_bloch(4) == stim.PauliString("+Y")
+    assert s.peek_bloch(4) == lestim.PauliString("+Y")
     s.postselect_x(8, desired_value=True)
-    assert s.peek_bloch(8) == stim.PauliString("-X")
+    assert s.peek_bloch(8) == lestim.PauliString("-X")
 
     s.postselect_z(9, desired_value=False)
-    assert s.peek_bloch(9) == stim.PauliString("+Z")
+    assert s.peek_bloch(9) == lestim.PauliString("+Z")
     with pytest.raises(ValueError, match="impossible"):
         s.postselect_z(10, desired_value=True)
 
     s.postselect_y(1000, desired_value=True)
-    assert s.peek_bloch(1000) == stim.PauliString("-Y")
+    assert s.peek_bloch(1000) == lestim.PauliString("-Y")
 
 
 def test_peek_pauli():
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
     assert s.peek_x(0) == 0
     assert s.peek_y(0) == 0
     assert s.peek_z(0) == +1
@@ -435,102 +435,102 @@ def test_peek_pauli():
 
 
 def test_do_circuit():
-    s = stim.TableauSimulator()
-    s.do_circuit(stim.Circuit("""
+    s = lestim.TableauSimulator()
+    s.do_circuit(lestim.Circuit("""
         H 0
     """))
-    assert s.peek_bloch(0) == stim.PauliString('+X')
+    assert s.peek_bloch(0) == lestim.PauliString('+X')
 
 
 def test_do_pauli_string():
-    s = stim.TableauSimulator()
-    s.do_pauli_string(stim.PauliString("IXYZ"))
-    assert s.peek_bloch(0) == stim.PauliString('+Z')
-    assert s.peek_bloch(1) == stim.PauliString('-Z')
-    assert s.peek_bloch(2) == stim.PauliString('-Z')
-    assert s.peek_bloch(3) == stim.PauliString('+Z')
+    s = lestim.TableauSimulator()
+    s.do_pauli_string(lestim.PauliString("IXYZ"))
+    assert s.peek_bloch(0) == lestim.PauliString('+Z')
+    assert s.peek_bloch(1) == lestim.PauliString('-Z')
+    assert s.peek_bloch(2) == lestim.PauliString('-Z')
+    assert s.peek_bloch(3) == lestim.PauliString('+Z')
 
 
 def test_do_tableau():
-    s = stim.TableauSimulator()
-    s.do_tableau(stim.Tableau.from_named_gate("H"), [0])
-    assert s.peek_bloch(0) == stim.PauliString('+X')
-    s.do_tableau(stim.Tableau.from_named_gate("CNOT"), [0, 1])
-    assert s.peek_bloch(0) == stim.PauliString('+I')
-    assert s.peek_observable_expectation(stim.PauliString('XX')) == +1
-    assert s.peek_observable_expectation(stim.PauliString('ZZ')) == +1
+    s = lestim.TableauSimulator()
+    s.do_tableau(lestim.Tableau.from_named_gate("H"), [0])
+    assert s.peek_bloch(0) == lestim.PauliString('+X')
+    s.do_tableau(lestim.Tableau.from_named_gate("CNOT"), [0, 1])
+    assert s.peek_bloch(0) == lestim.PauliString('+I')
+    assert s.peek_observable_expectation(lestim.PauliString('XX')) == +1
+    assert s.peek_observable_expectation(lestim.PauliString('ZZ')) == +1
 
     with pytest.raises(ValueError, match='len'):
-        s.do_tableau(stim.Tableau(1), [1, 2])
+        s.do_tableau(lestim.Tableau(1), [1, 2])
     with pytest.raises(ValueError, match='duplicates'):
-        s.do_tableau(stim.Tableau(3), [2, 3, 2])
+        s.do_tableau(lestim.Tableau(3), [2, 3, 2])
 
-    s.do_tableau(stim.Tableau(0), [])
+    s.do_tableau(lestim.Tableau(0), [])
 
 
 def test_c_xyz_zyx():
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
     s.c_xyz(0, 2)
     s.c_zyx(1, 2)
-    assert s.peek_bloch(0) == stim.PauliString("X")
-    assert s.peek_bloch(1) == stim.PauliString("Y")
-    assert s.peek_bloch(2) == stim.PauliString("Z")
+    assert s.peek_bloch(0) == lestim.PauliString("X")
+    assert s.peek_bloch(1) == lestim.PauliString("Y")
+    assert s.peek_bloch(2) == lestim.PauliString("Z")
 
 
 def test_gate_aliases():
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
     s.h_xz(0)
-    assert s.peek_bloch(0) == stim.PauliString("X")
+    assert s.peek_bloch(0) == lestim.PauliString("X")
 
     s.zcx(0, 1)
     assert s.canonical_stabilizers() == [
-        stim.PauliString("+XX"),
-        stim.PauliString("+ZZ")
+        lestim.PauliString("+XX"),
+        lestim.PauliString("+ZZ")
     ]
     s.cx(0, 1)
     assert s.canonical_stabilizers() == [
-        stim.PauliString("+X_"),
-        stim.PauliString("+_Z")
+        lestim.PauliString("+X_"),
+        lestim.PauliString("+_Z")
     ]
 
     s.zcy(0, 1)
     assert s.canonical_stabilizers() == [
-        stim.PauliString("+XY"),
-        stim.PauliString("+ZZ")
+        lestim.PauliString("+XY"),
+        lestim.PauliString("+ZZ")
     ]
 
     s.zcz(0, 1)
     assert s.canonical_stabilizers() == [
-        stim.PauliString("-XY"),
-        stim.PauliString("+ZZ")
+        lestim.PauliString("-XY"),
+        lestim.PauliString("+ZZ")
     ]
 
 
 def test_num_qubits():
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
     assert s.num_qubits == 0
     s.cx(3, 1)
     assert s.num_qubits == 4
 
 
 def test_set_state_from_state_vector():
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
     expected = [0.5, 0.5, 0, 0, -0.5, 0.5, 0, 0]
     s.set_state_from_state_vector(expected, endian='little')
     np.testing.assert_allclose(s.state_vector(), expected, atol=1e-6)
 
 
 def test_set_state_from_stabilizers():
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
     s.set_state_from_stabilizers([])
-    assert s.current_inverse_tableau() == stim.Tableau(0)
-    s.set_state_from_stabilizers([stim.PauliString("XXX"), stim.PauliString("_ZZ"), stim.PauliString("ZZ_")])
+    assert s.current_inverse_tableau() == lestim.Tableau(0)
+    s.set_state_from_stabilizers([lestim.PauliString("XXX"), lestim.PauliString("_ZZ"), lestim.PauliString("ZZ_")])
     np.testing.assert_allclose(s.state_vector(), [0.5**0.5, 0, 0, 0, 0, 0, 0, 0.5**0.5], atol=1e-6)
 
 
 def test_seed():
-    ss1 = [stim.TableauSimulator(seed=0) for _ in range(5)]
-    ss2 = [stim.TableauSimulator(seed=1) for _ in range(5)]
+    ss1 = [lestim.TableauSimulator(seed=0) for _ in range(5)]
+    ss2 = [lestim.TableauSimulator(seed=1) for _ in range(5)]
 
     def hadamard_and_measure(sim, reps=5):
         """Repeats Hadamard+measurement reps times and returns result as reps-bit integer."""
@@ -550,7 +550,7 @@ def test_seed():
 
 
 def test_copy_without_fresh_entropy():
-    s1 = stim.TableauSimulator(seed=0)
+    s1 = lestim.TableauSimulator(seed=0)
     s2 = s1.copy(copy_rng=True)
 
     for _ in range(100):
@@ -560,7 +560,7 @@ def test_copy_without_fresh_entropy():
 
 
 def test_copy_with_fresh_entropy():
-    s1 = stim.TableauSimulator(seed=0)
+    s1 = lestim.TableauSimulator(seed=0)
     s2 = s1.copy()
 
     eq = set()
@@ -572,8 +572,8 @@ def test_copy_with_fresh_entropy():
 
 
 def test_copy_with_explicit_seed():
-    s1 = stim.TableauSimulator(seed=0)
-    s2 = stim.TableauSimulator(seed=1)
+    s1 = lestim.TableauSimulator(seed=0)
+    s2 = lestim.TableauSimulator(seed=1)
     s3 = s1.copy(seed=1)
 
     eq = set()
@@ -591,18 +591,18 @@ def test_copy_with_explicit_seed():
 
 
 def test_copy_with_explicit_copy_rng_and_seed():
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
     with pytest.raises(ValueError, match='seed and copy_rng are incompatible'):
         _ = s.copy(copy_rng=True, seed=0)
 
 
 def test_do_circuit_instruction():
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
     assert s.peek_z(0) == +1
-    s.do(stim.Circuit("X 0")[0])
+    s.do(lestim.Circuit("X 0")[0])
     assert s.peek_z(0) == -1
 
-    s.do(stim.Circuit("""
+    s.do(lestim.Circuit("""
         REPEAT 100 {
             CNOT 0 1 1 2 2 3 3 4 4 5 5 6 6 7 7 0
         }
@@ -616,63 +616,63 @@ def test_do_circuit_instruction():
     assert s.peek_z(6) == +1
     assert s.peek_z(7) == +1
 
-    s.do(stim.Circuit("X 500")[0])
+    s.do(lestim.Circuit("X 500")[0])
     assert s.peek_z(499) == +1
     assert s.peek_z(500) == -1
     assert s.peek_z(501) == +1
 
 
 def test_measure_observable():
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
 
     with pytest.raises(ValueError, match="0 <= flip"):
-        s.measure_observable(stim.PauliString("XX"), flip_probability=-0.1)
+        s.measure_observable(lestim.PauliString("XX"), flip_probability=-0.1)
     with pytest.raises(ValueError, match="Hermitian"):
-        s.measure_observable(stim.PauliString("iXX"))
+        s.measure_observable(lestim.PauliString("iXX"))
 
     s.h(0)
     s.cnot(0, 1)
-    assert not s.measure_observable(stim.PauliString("ZZ"))
-    assert s.measure_observable(stim.PauliString("YY"))
-    assert s.measure_observable(stim.PauliString("-"))
-    assert not s.measure_observable(stim.PauliString(0))
-    assert not s.measure_observable(stim.PauliString(2))
-    assert not s.measure_observable(stim.PauliString(5))
-    n = sum(s.measure_observable(stim.PauliString(0), flip_probability=0.1) for _ in range(1000))
+    assert not s.measure_observable(lestim.PauliString("ZZ"))
+    assert s.measure_observable(lestim.PauliString("YY"))
+    assert s.measure_observable(lestim.PauliString("-"))
+    assert not s.measure_observable(lestim.PauliString(0))
+    assert not s.measure_observable(lestim.PauliString(2))
+    assert not s.measure_observable(lestim.PauliString(5))
+    n = sum(s.measure_observable(lestim.PauliString(0), flip_probability=0.1) for _ in range(1000))
     assert 25 <= n <= 300
 
 
 def test_x_error():
-    s = stim.TableauSimulator()
-    assert s.peek_bloch(0) == stim.PauliString("+Z")
+    s = lestim.TableauSimulator()
+    assert s.peek_bloch(0) == lestim.PauliString("+Z")
     s.x_error(0, 1, 2, p=0)
-    assert s.peek_bloch(0) == stim.PauliString("+Z")
+    assert s.peek_bloch(0) == lestim.PauliString("+Z")
     s.x_error(0, p=1)
-    assert s.peek_bloch(0) == stim.PauliString("-Z")
+    assert s.peek_bloch(0) == lestim.PauliString("-Z")
 
 
 def test_z_error():
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
     s.reset_x(0)
-    assert s.peek_bloch(0) == stim.PauliString("+X")
+    assert s.peek_bloch(0) == lestim.PauliString("+X")
     s.z_error(0, p=0)
-    assert s.peek_bloch(0) == stim.PauliString("+X")
+    assert s.peek_bloch(0) == lestim.PauliString("+X")
     s.z_error(0, p=1)
-    assert s.peek_bloch(0) == stim.PauliString("-X")
+    assert s.peek_bloch(0) == lestim.PauliString("-X")
 
 
 def test_y_error():
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
     s.reset_y(0)
-    assert s.peek_bloch(0) == stim.PauliString("+Y")
+    assert s.peek_bloch(0) == lestim.PauliString("+Y")
     s.x_error(0, p=0)
-    assert s.peek_bloch(0) == stim.PauliString("+Y")
+    assert s.peek_bloch(0) == lestim.PauliString("+Y")
     s.x_error(0, p=1)
-    assert s.peek_bloch(0) == stim.PauliString("-Y")
+    assert s.peek_bloch(0) == lestim.PauliString("-Y")
 
 
 def test_depolarize1_error():
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
     s.h(0)
     s.cnot(0, 1)
     t = s.current_inverse_tableau()
@@ -683,7 +683,7 @@ def test_depolarize1_error():
 
 
 def test_depolarize2_error():
-    s = stim.TableauSimulator()
+    s = lestim.TableauSimulator()
     s.h(0, 1)
     s.cnot(0, 2, 1, 3)
     t = s.current_inverse_tableau()
@@ -700,41 +700,41 @@ def test_depolarize2_error():
 
 
 def test_bad_inverse_padding_issue_is_fixed():
-    circuit = stim.Circuit()
+    circuit = lestim.Circuit()
     circuit.append("H", range(467))
-    sim = stim.TableauSimulator()
+    sim = lestim.TableauSimulator()
     sim.do(circuit)
     stabs = sim.canonical_stabilizers()
-    assert stabs[-1] == stim.PauliString(466 * '_' + 'X')
+    assert stabs[-1] == lestim.PauliString(466 * '_' + 'X')
 
 
 def test_postselect_observable():
-    sim = stim.TableauSimulator()
-    assert sim.peek_bloch(0) == stim.PauliString("+Z")
+    sim = lestim.TableauSimulator()
+    assert sim.peek_bloch(0) == lestim.PauliString("+Z")
 
-    sim.postselect_observable(stim.PauliString("+X"))
-    assert sim.peek_bloch(0) == stim.PauliString("+X")
+    sim.postselect_observable(lestim.PauliString("+X"))
+    assert sim.peek_bloch(0) == lestim.PauliString("+X")
 
-    sim.postselect_observable(stim.PauliString("+Z"))
-    assert sim.peek_bloch(0) == stim.PauliString("+Z")
+    sim.postselect_observable(lestim.PauliString("+Z"))
+    assert sim.peek_bloch(0) == lestim.PauliString("+Z")
 
-    sim.postselect_observable(stim.PauliString("-X"))
-    assert sim.peek_bloch(0) == stim.PauliString("-X")
+    sim.postselect_observable(lestim.PauliString("-X"))
+    assert sim.peek_bloch(0) == lestim.PauliString("-X")
 
-    sim.postselect_observable(stim.PauliString("+Z"))
-    assert sim.peek_bloch(0) == stim.PauliString("+Z")
+    sim.postselect_observable(lestim.PauliString("+Z"))
+    assert sim.peek_bloch(0) == lestim.PauliString("+Z")
 
-    sim.postselect_observable(stim.PauliString("-X"), desired_value=True)
-    assert sim.peek_bloch(0) == stim.PauliString("+X")
+    sim.postselect_observable(lestim.PauliString("-X"), desired_value=True)
+    assert sim.peek_bloch(0) == lestim.PauliString("+X")
 
     with pytest.raises(ValueError, match="impossible"):
-        sim.postselect_observable(stim.PauliString("-X"))
-    assert sim.peek_bloch(0) == stim.PauliString("+X")
+        sim.postselect_observable(lestim.PauliString("-X"))
+    assert sim.peek_bloch(0) == lestim.PauliString("+X")
 
     with pytest.raises(ValueError, match="imaginary sign"):
-        sim.postselect_observable(stim.PauliString("iZ"))
-    assert sim.peek_bloch(0) == stim.PauliString("+X")
+        sim.postselect_observable(lestim.PauliString("iZ"))
+    assert sim.peek_bloch(0) == lestim.PauliString("+X")
 
-    sim.postselect_observable(stim.PauliString("+XX"))
-    sim.postselect_observable(stim.PauliString("+ZZ"))
-    assert sim.peek_observable_expectation(stim.PauliString("+YY")) == -1
+    sim.postselect_observable(lestim.PauliString("+XX"))
+    sim.postselect_observable(lestim.PauliString("+ZZ"))
+    assert sim.peek_observable_expectation(lestim.PauliString("+YY")) == -1

--- a/src/stim/stabilizers/clifford_string.pybind.cc
+++ b/src/stim/stabilizers/clifford_string.pybind.cc
@@ -28,6 +28,7 @@ pybind11::class_<CliffordString<MAX_BITWORD_WIDTH>> stim_pybind::pybind_clifford
     return pybind11::class_<CliffordString<MAX_BITWORD_WIDTH>>(
         m,
         "CliffordString",
+        pybind11::module_local(),
         clean_doc_string(R"DOC(
             A tensor product of single qubit Clifford gates (e.g. "H \u2297 X \u2297 S").
 

--- a/src/stim/stabilizers/clifford_string_pybind_test.py
+++ b/src/stim/stabilizers/clifford_string_pybind_test.py
@@ -14,91 +14,91 @@
 
 import numpy as np
 import pytest
-import stim
+import lestim
 
 
 def test_trivial():
-    p = stim.CliffordString(3)
+    p = lestim.CliffordString(3)
     assert repr(p) == 'stim.CliffordString("I,I,I")'
     assert len(p) == 3
-    assert p[1:] == stim.CliffordString(2)
-    assert p[0] == stim.gate_data('I')
+    assert p[1:] == lestim.CliffordString(2)
+    assert p[0] == lestim.gate_data('I')
 
 
 def test_simple():
-    assert stim.CliffordString("X,Y,Z,H,SQRT_X,C_XYZ,H_NXZ") == stim.CliffordString("  X  ,   Y  ,  Z  , H_XZ , SQRT_X,C_XYZ,H_NXZ,   ")
-    p = stim.CliffordString("X,Y,Z,H,SQRT_X,C_XYZ,H_NXZ")
+    assert lestim.CliffordString("X,Y,Z,H,SQRT_X,C_XYZ,H_NXZ") == lestim.CliffordString("  X  ,   Y  ,  Z  , H_XZ , SQRT_X,C_XYZ,H_NXZ,   ")
+    p = lestim.CliffordString("X,Y,Z,H,SQRT_X,C_XYZ,H_NXZ")
     assert repr(p) == 'stim.CliffordString("X,Y,Z,H,SQRT_X,C_XYZ,H_NXZ")'
     assert str(p) == 'X,Y,Z,H,SQRT_X,C_XYZ,H_NXZ'
     assert len(p) == 7
-    assert p != stim.CliffordString("Y,Y,Z,H,SQRT_X,C_XYZ,H_NXZ")
-    assert not (p != stim.CliffordString("X,Y,Z,H,SQRT_X,C_XYZ,H_NXZ"))
-    assert not (p == stim.CliffordString("Y,Y,Z,H,SQRT_X,C_XYZ,H_NXZ"))
-    assert p[1::2] == stim.CliffordString("Y,H,C_XYZ")
+    assert p != lestim.CliffordString("Y,Y,Z,H,SQRT_X,C_XYZ,H_NXZ")
+    assert not (p != lestim.CliffordString("X,Y,Z,H,SQRT_X,C_XYZ,H_NXZ"))
+    assert not (p == lestim.CliffordString("Y,Y,Z,H,SQRT_X,C_XYZ,H_NXZ"))
+    assert p[1::2] == lestim.CliffordString("Y,H,C_XYZ")
 
-    assert stim.CliffordString(6) == stim.CliffordString("I,I,I,I,I,I")
+    assert lestim.CliffordString(6) == lestim.CliffordString("I,I,I,I,I,I")
 
-    assert stim.CliffordString(stim.PauliString("XYZ_XYZ")) == stim.CliffordString("X,Y,Z,I,X,Y,Z")
+    assert lestim.CliffordString(lestim.PauliString("XYZ_XYZ")) == lestim.CliffordString("X,Y,Z,I,X,Y,Z")
 
-    v = stim.CliffordString("X,Y,H")
-    v2 = stim.CliffordString(v)
+    v = lestim.CliffordString("X,Y,H")
+    v2 = lestim.CliffordString(v)
     assert v == v2
     assert v is not v2
 
-    assert stim.CliffordString(['X', 'Y', 'Z', stim.gate_data('H'), 'S']) == stim.CliffordString('X,Y,Z,H,S')
+    assert lestim.CliffordString(['X', 'Y', 'Z', lestim.gate_data('H'), 'S']) == lestim.CliffordString('X,Y,Z,H,S')
 
 
 def test_multiplication():
-    a = stim.CliffordString("Z,H,S,C_XYZ")
-    b = stim.CliffordString("S,Z,S,C_XYZ,I")
-    assert a * b == stim.CliffordString("S_DAG,SQRT_Y,Z,C_ZYX,I")
+    a = lestim.CliffordString("Z,H,S,C_XYZ")
+    b = lestim.CliffordString("S,Z,S,C_XYZ,I")
+    assert a * b == lestim.CliffordString("S_DAG,SQRT_Y,Z,C_ZYX,I")
     a *= b
-    assert a == stim.CliffordString("S_DAG,SQRT_Y,Z,C_ZYX,I")
+    assert a == lestim.CliffordString("S_DAG,SQRT_Y,Z,C_ZYX,I")
 
-    assert stim.CliffordString("X") * stim.CliffordString("H") == stim.CliffordString("H") * stim.CliffordString("Z")
-    assert stim.CliffordString("X") * stim.CliffordString("H") != stim.CliffordString("Z") * stim.CliffordString("H")
-    assert stim.CliffordString("X") * stim.CliffordString("H") == stim.CliffordString("SQRT_Y")
+    assert lestim.CliffordString("X") * lestim.CliffordString("H") == lestim.CliffordString("H") * lestim.CliffordString("Z")
+    assert lestim.CliffordString("X") * lestim.CliffordString("H") != lestim.CliffordString("Z") * lestim.CliffordString("H")
+    assert lestim.CliffordString("X") * lestim.CliffordString("H") == lestim.CliffordString("SQRT_Y")
 
 
 def test_random():
-    c1 = stim.CliffordString.random(128)
-    c2 = stim.CliffordString.random(128)
+    c1 = lestim.CliffordString.random(128)
+    c2 = lestim.CliffordString.random(128)
     assert len(c1) == len(c2) == 128
     assert c1 != c2
 
 
 def test_set_item():
-    c = stim.CliffordString(5)
+    c = lestim.CliffordString(5)
     c[1] = "H"
-    assert c == stim.CliffordString("I,H,I,I,I")
+    assert c == lestim.CliffordString("I,H,I,I,I")
     with pytest.raises(ValueError, match="index"):
         c[2:3] = None
     with pytest.raises(ValueError, match="index"):
         c[2] = None
-    c[2:4] = stim.CliffordString("X,Y")
-    assert c == stim.CliffordString("I,H,X,Y,I")
-    c[::2] = stim.CliffordString("S,Z,S_DAG")
-    assert c == stim.CliffordString("S,H,Z,Y,S_DAG")
+    c[2:4] = lestim.CliffordString("X,Y")
+    assert c == lestim.CliffordString("I,H,X,Y,I")
+    c[::2] = lestim.CliffordString("S,Z,S_DAG")
+    assert c == lestim.CliffordString("S,H,Z,Y,S_DAG")
     c[:] = 'H'
-    assert c == stim.CliffordString("H,H,H,H,H")
-    c[:-2] = stim.gate_data('S')
-    assert c == stim.CliffordString("S,S,S,H,H")
-    c[0] = stim.gate_data('X')
-    assert c == stim.CliffordString("X,S,S,H,H")
+    assert c == lestim.CliffordString("H,H,H,H,H")
+    c[:-2] = lestim.gate_data('S')
+    assert c == lestim.CliffordString("S,S,S,H,H")
+    c[0] = lestim.gate_data('X')
+    assert c == lestim.CliffordString("X,S,S,H,H")
 
     with pytest.raises(ValueError, match="object of type"):
-        c[0] = stim.CliffordString("Y")
+        c[0] = lestim.CliffordString("Y")
     with pytest.raises(ValueError, match="Length mismatch"):
-        c[:2] = stim.CliffordString("Y")
-    assert c == stim.CliffordString("X,S,S,H,H")
-    c[:2] = stim.CliffordString("Y,Y")
-    assert c == stim.CliffordString("Y,Y,S,H,H")
+        c[:2] = lestim.CliffordString("Y")
+    assert c == lestim.CliffordString("X,S,S,H,H")
+    c[:2] = lestim.CliffordString("Y,Y")
+    assert c == lestim.CliffordString("Y,Y,S,H,H")
 
 
 def all_cliffords_string_from_gate_data():
-    c = stim.CliffordString(24)
+    c = lestim.CliffordString(24)
     r = 0
-    for g in stim.gate_data().values():
+    for g in lestim.gate_data().values():
         if g.is_unitary and g.is_single_qubit_gate:
             c[r] = g
             r += 1
@@ -106,8 +106,8 @@ def all_cliffords_string_from_gate_data():
 
 
 def test_x_outputs():
-    paulis, signs = stim.CliffordString("I,X,Y,Z,H,S,S_DAG,C_XYZ,C_ZYX,SQRT_X,SQRT_X_DAG").x_outputs()
-    assert paulis == stim.PauliString("XXXXZYYYZXX")
+    paulis, signs = lestim.CliffordString("I,X,Y,Z,H,S,S_DAG,C_XYZ,C_ZYX,SQRT_X,SQRT_X_DAG").x_outputs()
+    assert paulis == lestim.PauliString("XXXXZYYYZXX")
     np.testing.assert_array_equal(signs, [0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 0])
 
     c = all_cliffords_string_from_gate_data()
@@ -119,8 +119,8 @@ def test_x_outputs():
 
 
 def test_y_outputs():
-    paulis, signs = stim.CliffordString("I,X,Y,Z,H,S,S_DAG,C_XYZ,C_ZYX,SQRT_X,SQRT_X_DAG").y_outputs()
-    assert paulis == stim.PauliString("YYYYYXXZXZZ")
+    paulis, signs = lestim.CliffordString("I,X,Y,Z,H,S,S_DAG,C_XYZ,C_ZYX,SQRT_X,SQRT_X_DAG").y_outputs()
+    assert paulis == lestim.PauliString("YYYYYXXZXZZ")
     np.testing.assert_array_equal(signs, [0, 1, 0, 1, 1, 1, 0, 0, 0, 0, 1])
 
     c = all_cliffords_string_from_gate_data()
@@ -132,8 +132,8 @@ def test_y_outputs():
 
 
 def test_z_outputs():
-    paulis, signs = stim.CliffordString("I,X,Y,Z,H,S,S_DAG,C_XYZ,C_ZYX,SQRT_X,SQRT_X_DAG").z_outputs()
-    assert paulis == stim.PauliString("ZZZZXZZXYYY")
+    paulis, signs = lestim.CliffordString("I,X,Y,Z,H,S,S_DAG,C_XYZ,C_ZYX,SQRT_X,SQRT_X_DAG").z_outputs()
+    assert paulis == lestim.PauliString("ZZZZXZZXYYY")
     np.testing.assert_array_equal(signs, [0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0])
 
     c = all_cliffords_string_from_gate_data()
@@ -145,6 +145,6 @@ def test_z_outputs():
 
 
 def test_all_cliffords_string():
-    c = stim.CliffordString.all_cliffords_string()
+    c = lestim.CliffordString.all_cliffords_string()
     assert len(c) == 24
     assert set(e.name for e in all_cliffords_string_from_gate_data()) == set(e.name for e in c)

--- a/src/stim/stabilizers/flow_pybind_test.py
+++ b/src/stim/stabilizers/flow_pybind_test.py
@@ -12,130 +12,130 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import numpy as np
-import stim
+import lestim
 import pytest
 
 
 def test_basics():
-    p = stim.Flow()
-    assert p.input_copy() == stim.PauliString(0)
-    assert p.output_copy() == stim.PauliString(0)
+    p = lestim.Flow()
+    assert p.input_copy() == lestim.PauliString(0)
+    assert p.output_copy() == lestim.PauliString(0)
     assert p.measurements_copy() == []
     assert str(p) == "1 -> 1"
     assert repr(p) == 'stim.Flow("1 -> 1")'
 
-    p = stim.Flow(
-        input=stim.PauliString("XX"),
-        output=stim.PauliString("-YYZ"),
+    p = lestim.Flow(
+        input=lestim.PauliString("XX"),
+        output=lestim.PauliString("-YYZ"),
         measurements=[-1, 2, 3],
     )
-    assert p.input_copy() == stim.PauliString("XX")
-    assert p.output_copy() == stim.PauliString("-YYZ")
+    assert p.input_copy() == lestim.PauliString("XX")
+    assert p.output_copy() == lestim.PauliString("-YYZ")
     assert p.measurements_copy() == [-1, 2, 3]
     assert str(p) == "XX -> -YYZ xor rec[-1] xor rec[2] xor rec[3]"
     assert repr(p) == 'stim.Flow("XX -> -YYZ xor rec[-1] xor rec[2] xor rec[3]")'
 
-    p = stim.Flow("-X1*Z2 -> Y3 xor rec[-1]")
-    assert p.input_copy() == stim.PauliString("-_XZ")
-    assert p.output_copy() == stim.PauliString("___Y")
+    p = lestim.Flow("-X1*Z2 -> Y3 xor rec[-1]")
+    assert p.input_copy() == lestim.PauliString("-_XZ")
+    assert p.output_copy() == lestim.PauliString("___Y")
     assert p.measurements_copy() == [-1]
     assert str(p) == "-_XZ -> ___Y xor rec[-1]"
     assert repr(p) == 'stim.Flow("-_XZ -> ___Y xor rec[-1]")'
 
-    p = stim.Flow("X20 -> Y xor rec[-1]")
-    assert p.input_copy() == stim.PauliString("X20")
-    assert p.output_copy() == stim.PauliString("Y")
+    p = lestim.Flow("X20 -> Y xor rec[-1]")
+    assert p.input_copy() == lestim.PauliString("X20")
+    assert p.output_copy() == lestim.PauliString("Y")
     assert p.measurements_copy() == [-1]
     assert str(p) == "X20 -> Y0 xor rec[-1]"
     assert repr(p) == 'stim.Flow("X20 -> Y0 xor rec[-1]")'
 
-    p = stim.Flow("X20*I21 -> Y xor rec[-1]")
-    assert p.input_copy() == stim.PauliString("____________________X_")
-    assert p.output_copy() == stim.PauliString("Y")
+    p = lestim.Flow("X20*I21 -> Y xor rec[-1]")
+    assert p.input_copy() == lestim.PauliString("____________________X_")
+    assert p.output_copy() == lestim.PauliString("Y")
     assert p.measurements_copy() == [-1]
     assert str(p) == "____________________X_ -> Y xor rec[-1]"
     assert repr(p) == 'stim.Flow("____________________X_ -> Y xor rec[-1]")'
 
-    p = stim.Flow("iX -> iY")
-    assert p.input_copy() == stim.PauliString("X")
-    assert p.output_copy() == stim.PauliString("Y")
+    p = lestim.Flow("iX -> iY")
+    assert p.input_copy() == lestim.PauliString("X")
+    assert p.output_copy() == lestim.PauliString("Y")
     assert p.measurements_copy() == []
 
-    p = stim.Flow(input=stim.PauliString("iX"), output=stim.PauliString("iY"))
-    assert p.input_copy() == stim.PauliString("X")
-    assert p.output_copy() == stim.PauliString("Y")
+    p = lestim.Flow(input=lestim.PauliString("iX"), output=lestim.PauliString("iY"))
+    assert p.input_copy() == lestim.PauliString("X")
+    assert p.output_copy() == lestim.PauliString("Y")
     assert p.measurements_copy() == []
 
     with pytest.raises(ValueError, match="Anti-Hermitian"):
-        stim.Flow("iX -> Y")
+        lestim.Flow("iX -> Y")
     with pytest.raises(ValueError, match="Anti-Hermitian"):
-        stim.Flow(input=stim.PauliString("iX"), output=stim.PauliString("Y"))
+        lestim.Flow(input=lestim.PauliString("iX"), output=lestim.PauliString("Y"))
 
 
 def test_equality():
-    assert not (stim.Flow() == None)
-    assert not (stim.Flow() == "other object")
-    assert not (stim.Flow() == object())
-    assert stim.Flow() != None
-    assert stim.Flow() != "other object"
-    assert stim.Flow() != object()
+    assert not (lestim.Flow() == None)
+    assert not (lestim.Flow() == "other object")
+    assert not (lestim.Flow() == object())
+    assert lestim.Flow() != None
+    assert lestim.Flow() != "other object"
+    assert lestim.Flow() != object()
 
-    assert stim.Flow('X -> Y') == stim.Flow('X -> Y')
-    assert stim.Flow('X -> X') != stim.Flow('X -> Y')
-    assert not (stim.Flow('X -> Y') != stim.Flow('X -> Y'))
-    assert not (stim.Flow('X -> Y') == stim.Flow('X -> X'))
+    assert lestim.Flow('X -> Y') == lestim.Flow('X -> Y')
+    assert lestim.Flow('X -> X') != lestim.Flow('X -> Y')
+    assert not (lestim.Flow('X -> Y') != lestim.Flow('X -> Y'))
+    assert not (lestim.Flow('X -> Y') == lestim.Flow('X -> X'))
 
-    assert stim.Flow("X -> X xor rec[-1]") == stim.Flow("X -> X xor rec[-1]")
-    assert stim.Flow("X -> X xor rec[-1]") != stim.Flow("Y -> X xor rec[-1]")
-    assert stim.Flow("X -> X xor rec[-1]") != stim.Flow("X -> Y xor rec[-1]")
-    assert stim.Flow("X -> X xor rec[-1]") != stim.Flow("X -> X xor rec[-2]")
+    assert lestim.Flow("X -> X xor rec[-1]") == lestim.Flow("X -> X xor rec[-1]")
+    assert lestim.Flow("X -> X xor rec[-1]") != lestim.Flow("Y -> X xor rec[-1]")
+    assert lestim.Flow("X -> X xor rec[-1]") != lestim.Flow("X -> Y xor rec[-1]")
+    assert lestim.Flow("X -> X xor rec[-1]") != lestim.Flow("X -> X xor rec[-2]")
 
 
 @pytest.mark.parametrize("value", [
-    stim.Flow(),
-    stim.Flow("X -> Y xor rec[-1]"),
-    stim.Flow("X -> 1"),
-    stim.Flow("-X -> Y"),
-    stim.Flow("X -> -Y"),
-    stim.Flow("-X -> -Y"),
-    stim.Flow("1 -> X"),
-    stim.Flow("X__________________ -> ________Y"),
+    lestim.Flow(),
+    lestim.Flow("X -> Y xor rec[-1]"),
+    lestim.Flow("X -> 1"),
+    lestim.Flow("-X -> Y"),
+    lestim.Flow("X -> -Y"),
+    lestim.Flow("-X -> -Y"),
+    lestim.Flow("1 -> X"),
+    lestim.Flow("X__________________ -> ________Y"),
 ])
 def test_repr(value):
-    assert eval(repr(value), {'stim': stim}) == value
-    assert repr(eval(repr(value), {'stim': stim})) == repr(value)
+    assert eval(repr(value), {'stim': lestim}) == value
+    assert repr(eval(repr(value), {'stim': lestim})) == repr(value)
 
 
 def test_obs_flows():
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         OBSERVABLE_INCLUDE(1) X2
-    """).has_flow(stim.Flow("X2 -> obs[1]"))
-    assert not stim.Circuit("""
+    """).has_flow(lestim.Flow("X2 -> obs[1]"))
+    assert not lestim.Circuit("""
         OBSERVABLE_INCLUDE(1) !X2
-    """).has_flow(stim.Flow("X2 -> obs[1]"))
-    assert stim.Circuit("""
+    """).has_flow(lestim.Flow("X2 -> obs[1]"))
+    assert lestim.Circuit("""
         OBSERVABLE_INCLUDE(1) !X2
-    """).has_flow(stim.Flow("X2 -> obs[1]"), unsigned=True)
-    assert stim.Circuit("""
+    """).has_flow(lestim.Flow("X2 -> obs[1]"), unsigned=True)
+    assert lestim.Circuit("""
         OBSERVABLE_INCLUDE(1) !X2
-    """).has_flow(stim.Flow("-X2 -> obs[1]"))
-    assert not stim.Circuit("""
+    """).has_flow(lestim.Flow("-X2 -> obs[1]"))
+    assert not lestim.Circuit("""
         OBSERVABLE_INCLUDE(1) X2
-    """).has_flow(stim.Flow("Y2 -> obs[1]"))
-    assert not stim.Circuit("""
+    """).has_flow(lestim.Flow("Y2 -> obs[1]"))
+    assert not lestim.Circuit("""
         OBSERVABLE_INCLUDE(1) X2
-    """).has_flow(stim.Flow("Y2 -> obs[1]"), unsigned=True)
+    """).has_flow(lestim.Flow("Y2 -> obs[1]"), unsigned=True)
 
 
 def test_obs_include_pauli_terms_sensitivity():
-    _, obs = stim.Circuit("""
+    _, obs = lestim.Circuit("""
         OBSERVABLE_INCLUDE(0) X0
         X_ERROR(0.5) 0
         OBSERVABLE_INCLUDE(0) X0
     """).compile_detector_sampler().sample(shots=1024, separate_observables=True)
     assert np.count_nonzero(obs) == 0
 
-    _, obs = stim.Circuit("""
+    _, obs = lestim.Circuit("""
         OBSERVABLE_INCLUDE(0) X0
         OBSERVABLE_INCLUDE(1) Y0
         OBSERVABLE_INCLUDE(2) Z0
@@ -149,7 +149,7 @@ def test_obs_include_pauli_terms_sensitivity():
     assert 256 <= ys <= 768
     assert zs == ys
 
-    _, obs = stim.Circuit("""
+    _, obs = lestim.Circuit("""
         OBSERVABLE_INCLUDE(0) X0
         OBSERVABLE_INCLUDE(1) Y0
         OBSERVABLE_INCLUDE(2) Z0
@@ -163,7 +163,7 @@ def test_obs_include_pauli_terms_sensitivity():
     assert 256 <= xs <= 768
     assert zs == xs
 
-    _, obs = stim.Circuit("""
+    _, obs = lestim.Circuit("""
         OBSERVABLE_INCLUDE(0) X0
         OBSERVABLE_INCLUDE(1) Y0
         OBSERVABLE_INCLUDE(2) Z0
@@ -179,21 +179,21 @@ def test_obs_include_pauli_terms_sensitivity():
 
 
 def test_flow_canonicalization():
-    assert stim.Flow(measurements=[4, 0, 4]) == stim.Flow(measurements=[0])
-    assert stim.Flow(included_observables=[4, 0, 4]) == stim.Flow(included_observables=[0])
+    assert lestim.Flow(measurements=[4, 0, 4]) == lestim.Flow(measurements=[0])
+    assert lestim.Flow(included_observables=[4, 0, 4]) == lestim.Flow(included_observables=[0])
 
 
 def test_flow_multiplication():
-    assert stim.Flow("XYZ -> 1") * stim.Flow("1 -> XYZ") == stim.Flow("XYZ -> XYZ")
-    assert stim.Flow("XX_ -> 1") * stim.Flow("_XX -> 1") == stim.Flow("X_X -> 1")
-    assert stim.Flow("1 -> XX_") * stim.Flow("1 -> _XX") == stim.Flow("1 -> X_X")
-    assert stim.Flow("1 -> rec[-1] xor rec[-3]") * stim.Flow("1 -> rec[-1] xor rec[-2]") == stim.Flow("1 -> rec[-2] xor rec[-3]")
-    assert stim.Flow("1 -> obs[1] xor obs[3]") * stim.Flow("1 -> obs[1] xor obs[2]") == stim.Flow("1 -> obs[2] xor obs[3]")
-    assert stim.Flow("X -> X") * stim.Flow("Z -> Z") == stim.Flow("Y -> Y")
-    assert stim.Flow("1 -> XX") * stim.Flow("1 -> ZZ") == stim.Flow("1 -> -YY")
-    assert stim.Flow("1 -> obs[1]") * stim.Flow("1 -> obs[1]") == stim.Flow("1 -> 1")
-    assert stim.Flow("1 -> rec[1]") * stim.Flow("1 -> rec[1]") == stim.Flow("1 -> 1")
+    assert lestim.Flow("XYZ -> 1") * lestim.Flow("1 -> XYZ") == lestim.Flow("XYZ -> XYZ")
+    assert lestim.Flow("XX_ -> 1") * lestim.Flow("_XX -> 1") == lestim.Flow("X_X -> 1")
+    assert lestim.Flow("1 -> XX_") * lestim.Flow("1 -> _XX") == lestim.Flow("1 -> X_X")
+    assert lestim.Flow("1 -> rec[-1] xor rec[-3]") * lestim.Flow("1 -> rec[-1] xor rec[-2]") == lestim.Flow("1 -> rec[-2] xor rec[-3]")
+    assert lestim.Flow("1 -> obs[1] xor obs[3]") * lestim.Flow("1 -> obs[1] xor obs[2]") == lestim.Flow("1 -> obs[2] xor obs[3]")
+    assert lestim.Flow("X -> X") * lestim.Flow("Z -> Z") == lestim.Flow("Y -> Y")
+    assert lestim.Flow("1 -> XX") * lestim.Flow("1 -> ZZ") == lestim.Flow("1 -> -YY")
+    assert lestim.Flow("1 -> obs[1]") * lestim.Flow("1 -> obs[1]") == lestim.Flow("1 -> 1")
+    assert lestim.Flow("1 -> rec[1]") * lestim.Flow("1 -> rec[1]") == lestim.Flow("1 -> 1")
     with pytest.raises(ValueError, match="anticommute"):
-        _ = stim.Flow("1 -> X") * stim.Flow("1 -> Y")
+        _ = lestim.Flow("1 -> X") * lestim.Flow("1 -> Y")
     with pytest.raises(ValueError, match="anticommute"):
-        _ = stim.Flow("1 -> Y") * stim.Flow("1 -> X")
+        _ = lestim.Flow("1 -> Y") * lestim.Flow("1 -> X")

--- a/src/stim/stabilizers/pauli_string_pybind_test.py
+++ b/src/stim/stabilizers/pauli_string_pybind_test.py
@@ -13,19 +13,19 @@
 # limitations under the License.
 import itertools
 import numpy as np
-import stim
+import lestim
 import pytest
 
 
 def test_identity():
-    p = stim.PauliString(3)
+    p = lestim.PauliString(3)
     assert len(p) == 3
     assert p[0] == p[1] == p[2] == 0
     assert p.sign == +1
 
 
 def test_from_str():
-    p = stim.PauliString("-_XYZ_ZYX")
+    p = lestim.PauliString("-_XYZ_ZYX")
     assert len(p) == 8
     assert p[0] == 0
     assert p[1] == 1
@@ -37,120 +37,120 @@ def test_from_str():
     assert p[7] == 1
     assert p.sign == -1
 
-    p = stim.PauliString("")
+    p = lestim.PauliString("")
     assert len(p) == 0
     assert p.sign == +1
 
-    p = stim.PauliString("X")
+    p = lestim.PauliString("X")
     assert len(p) == 1
     assert p[0] == 1
     assert p.sign == +1
 
-    p = stim.PauliString("+X")
+    p = lestim.PauliString("+X")
     assert len(p) == 1
     assert p[0] == 1
     assert p.sign == +1
 
-    p = stim.PauliString("iX")
+    p = lestim.PauliString("iX")
     assert len(p) == 1
     assert p[0] == 1
     assert p.sign == 1j
 
-    p = stim.PauliString("+iX")
+    p = lestim.PauliString("+iX")
     assert len(p) == 1
     assert p[0] == 1
     assert p.sign == 1j
 
-    p = stim.PauliString("-iX")
+    p = lestim.PauliString("-iX")
     assert len(p) == 1
     assert p[0] == 1
     assert p.sign == -1j
 
-    assert stim.PauliString("X5*Y10") == stim.PauliString("_____X____Y")
-    assert stim.PauliString("X5*Y5") == stim.PauliString("iZ5")
+    assert lestim.PauliString("X5*Y10") == lestim.PauliString("_____X____Y")
+    assert lestim.PauliString("X5*Y5") == lestim.PauliString("iZ5")
 
 
 def test_equality():
-    assert not (stim.PauliString(4) == None)
-    assert not (stim.PauliString(4) == "other object")
-    assert not (stim.PauliString(4) == object())
-    assert stim.PauliString(4) != None
-    assert stim.PauliString(4) != "other object"
-    assert stim.PauliString(4) != object()
+    assert not (lestim.PauliString(4) == None)
+    assert not (lestim.PauliString(4) == "other object")
+    assert not (lestim.PauliString(4) == object())
+    assert lestim.PauliString(4) != None
+    assert lestim.PauliString(4) != "other object"
+    assert lestim.PauliString(4) != object()
 
-    assert stim.PauliString(4) == stim.PauliString(4)
-    assert stim.PauliString(3) != stim.PauliString(4)
-    assert not (stim.PauliString(4) != stim.PauliString(4))
-    assert not (stim.PauliString(3) == stim.PauliString(4))
+    assert lestim.PauliString(4) == lestim.PauliString(4)
+    assert lestim.PauliString(3) != lestim.PauliString(4)
+    assert not (lestim.PauliString(4) != lestim.PauliString(4))
+    assert not (lestim.PauliString(3) == lestim.PauliString(4))
 
-    assert stim.PauliString("+X") == stim.PauliString("+X")
-    assert stim.PauliString("+X") != stim.PauliString("-X")
-    assert stim.PauliString("+X") != stim.PauliString("+Y")
-    assert stim.PauliString("+X") != stim.PauliString("-Y")
-    assert stim.PauliString("+X") != stim.PauliString("+iX")
-    assert stim.PauliString("+X") != stim.PauliString("-iX")
+    assert lestim.PauliString("+X") == lestim.PauliString("+X")
+    assert lestim.PauliString("+X") != lestim.PauliString("-X")
+    assert lestim.PauliString("+X") != lestim.PauliString("+Y")
+    assert lestim.PauliString("+X") != lestim.PauliString("-Y")
+    assert lestim.PauliString("+X") != lestim.PauliString("+iX")
+    assert lestim.PauliString("+X") != lestim.PauliString("-iX")
 
-    assert stim.PauliString("__") != stim.PauliString("_X")
-    assert stim.PauliString("__") != stim.PauliString("X_")
-    assert stim.PauliString("__") != stim.PauliString("XX")
-    assert stim.PauliString("__") == stim.PauliString("__")
+    assert lestim.PauliString("__") != lestim.PauliString("_X")
+    assert lestim.PauliString("__") != lestim.PauliString("X_")
+    assert lestim.PauliString("__") != lestim.PauliString("XX")
+    assert lestim.PauliString("__") == lestim.PauliString("__")
 
 
 def test_random():
-    p1 = stim.PauliString.random(100)
-    p2 = stim.PauliString.random(100)
+    p1 = lestim.PauliString.random(100)
+    p2 = lestim.PauliString.random(100)
     assert p1 != p2
 
-    seen_signs = {stim.PauliString.random(1).sign for _ in range(200)}
+    seen_signs = {lestim.PauliString.random(1).sign for _ in range(200)}
     assert seen_signs == {1, -1}
 
-    seen_signs = {stim.PauliString.random(1, allow_imaginary=True).sign for _ in range(200)}
+    seen_signs = {lestim.PauliString.random(1, allow_imaginary=True).sign for _ in range(200)}
     assert seen_signs == {1, -1, 1j, -1j}
 
 
 def test_str():
-    assert str(stim.PauliString(3)) == "+___"
-    assert str(stim.PauliString("XYZ")) == "+XYZ"
-    assert str(stim.PauliString("-XYZ")) == "-XYZ"
-    assert str(stim.PauliString("iXYZ")) == "+iXYZ"
-    assert str(stim.PauliString("-iXYZ")) == "-iXYZ"
+    assert str(lestim.PauliString(3)) == "+___"
+    assert str(lestim.PauliString("XYZ")) == "+XYZ"
+    assert str(lestim.PauliString("-XYZ")) == "-XYZ"
+    assert str(lestim.PauliString("iXYZ")) == "+iXYZ"
+    assert str(lestim.PauliString("-iXYZ")) == "-iXYZ"
 
 
 def test_repr():
-    assert repr(stim.PauliString(3)) == 'stim.PauliString("+___")'
-    assert repr(stim.PauliString("-XYZ")) == 'stim.PauliString("-XYZ")'
+    assert repr(lestim.PauliString(3)) == 'stim.PauliString("+___")'
+    assert repr(lestim.PauliString("-XYZ")) == 'stim.PauliString("-XYZ")'
     vs = [
-        stim.PauliString(""),
-        stim.PauliString("ZXYZZ"),
-        stim.PauliString("-XYZ"),
-        stim.PauliString("I"),
-        stim.PauliString("iIXYZ"),
-        stim.PauliString("-iIXYZ"),
+        lestim.PauliString(""),
+        lestim.PauliString("ZXYZZ"),
+        lestim.PauliString("-XYZ"),
+        lestim.PauliString("I"),
+        lestim.PauliString("iIXYZ"),
+        lestim.PauliString("-iIXYZ"),
     ]
     for v in vs:
         r = repr(v)
-        assert eval(r, {'stim': stim}) == v
+        assert eval(r, {'stim': lestim}) == v
 
 def test_to_tableau():
-    p = stim.PauliString("XZ_Y")
+    p = lestim.PauliString("XZ_Y")
     t = p.to_tableau()
-    assert t.x_output(0) == stim.PauliString("+X___")
-    assert t.x_output(1) == stim.PauliString("-_X__")
-    assert t.x_output(2) == stim.PauliString("+__X_")
-    assert t.x_output(3) == stim.PauliString("-___X")
-    assert t.z_output(0) == stim.PauliString("-Z___")
-    assert t.z_output(1) == stim.PauliString("+_Z__")
-    assert t.z_output(2) == stim.PauliString("+__Z_")
-    assert t.z_output(3) == stim.PauliString("-___Z")
+    assert t.x_output(0) == lestim.PauliString("+X___")
+    assert t.x_output(1) == lestim.PauliString("-_X__")
+    assert t.x_output(2) == lestim.PauliString("+__X_")
+    assert t.x_output(3) == lestim.PauliString("-___X")
+    assert t.z_output(0) == lestim.PauliString("-Z___")
+    assert t.z_output(1) == lestim.PauliString("+_Z__")
+    assert t.z_output(2) == lestim.PauliString("+__Z_")
+    assert t.z_output(3) == lestim.PauliString("-___Z")
 
-    p_random = stim.PauliString.random(32)
+    p_random = lestim.PauliString.random(32)
     p_random.sign = 1
     p_random_roundtrip = p_random.to_tableau().to_pauli_string()
     assert p_random == p_random_roundtrip
 
 def test_commutes():
     def c(a: str, b: str) -> bool:
-        return stim.PauliString(a).commutes(stim.PauliString(b))
+        return lestim.PauliString(a).commutes(lestim.PauliString(b))
 
     assert c("", "")
     assert c("X", "_")
@@ -167,15 +167,15 @@ def test_commutes():
 
 
 def test_product():
-    assert stim.PauliString("") * stim.PauliString("") == stim.PauliString("")
-    assert stim.PauliString("i") * stim.PauliString("i") == stim.PauliString("-")
-    assert stim.PauliString("i") * stim.PauliString("-i") == stim.PauliString("+")
-    assert stim.PauliString("-i") * stim.PauliString("-i") == stim.PauliString("-")
-    assert stim.PauliString("i") * stim.PauliString("-") == stim.PauliString("-i")
+    assert lestim.PauliString("") * lestim.PauliString("") == lestim.PauliString("")
+    assert lestim.PauliString("i") * lestim.PauliString("i") == lestim.PauliString("-")
+    assert lestim.PauliString("i") * lestim.PauliString("-i") == lestim.PauliString("+")
+    assert lestim.PauliString("-i") * lestim.PauliString("-i") == lestim.PauliString("-")
+    assert lestim.PauliString("i") * lestim.PauliString("-") == lestim.PauliString("-i")
 
-    x = stim.PauliString("X")
-    y = stim.PauliString("Y")
-    z = stim.PauliString("Z")
+    x = lestim.PauliString("X")
+    y = lestim.PauliString("Y")
+    z = lestim.PauliString("Z")
 
     assert x == +1 * x == x * +1 == +x
     assert x * -1 == -x == -1 * x
@@ -183,86 +183,86 @@ def test_product():
     assert (-x).sign == -1
     assert -(-x) == x
 
-    assert stim.PauliString(10) * stim.PauliString(11) == stim.PauliString(11)
+    assert lestim.PauliString(10) * lestim.PauliString(11) == lestim.PauliString(11)
 
-    assert x * z == stim.PauliString("-iY")
-    assert x * x == stim.PauliString(1)
-    assert x * y == stim.PauliString("iZ")
-    assert y * x == stim.PauliString("-iZ")
+    assert x * z == lestim.PauliString("-iY")
+    assert x * x == lestim.PauliString(1)
+    assert x * y == lestim.PauliString("iZ")
+    assert y * x == lestim.PauliString("-iZ")
     assert x * y == 1j * z
     assert y * x == z * -1j
     assert x.extended_product(y) == (1, 1j * z)
     assert y.extended_product(x) == (1, -1j * z)
-    assert x.extended_product(x) == (1, stim.PauliString(1))
+    assert x.extended_product(x) == (1, lestim.PauliString(1))
 
-    xx = stim.PauliString("+XX")
-    yy = stim.PauliString("+YY")
-    zz = stim.PauliString("+ZZ")
+    xx = lestim.PauliString("+XX")
+    yy = lestim.PauliString("+YY")
+    zz = lestim.PauliString("+ZZ")
     assert xx * zz == -yy
     assert xx.extended_product(zz) == (1, -yy)
 
 
 def test_inplace_product():
-    p = stim.PauliString("X")
+    p = lestim.PauliString("X")
     alias = p
 
     p *= 1j
-    assert alias == stim.PauliString("iX")
+    assert alias == lestim.PauliString("iX")
     assert alias is p
     p *= 1j
-    assert alias == stim.PauliString("-X")
+    assert alias == lestim.PauliString("-X")
     p *= 1j
-    assert alias == stim.PauliString("-iX")
+    assert alias == lestim.PauliString("-iX")
     p *= 1j
-    assert alias == stim.PauliString("+X")
+    assert alias == lestim.PauliString("+X")
 
-    p *= stim.PauliString("Z")
-    assert alias == stim.PauliString("-iY")
+    p *= lestim.PauliString("Z")
+    assert alias == lestim.PauliString("-iY")
 
     p *= -1j
-    assert alias == stim.PauliString("-Y")
+    assert alias == lestim.PauliString("-Y")
     p *= -1j
-    assert alias == stim.PauliString("iY")
+    assert alias == lestim.PauliString("iY")
     p *= -1j
-    assert alias == stim.PauliString("+Y")
+    assert alias == lestim.PauliString("+Y")
     p *= -1j
-    assert alias == stim.PauliString("-iY")
+    assert alias == lestim.PauliString("-iY")
 
-    p *= stim.PauliString("i_")
-    assert alias == stim.PauliString("+Y")
-    p *= stim.PauliString("i_")
-    assert alias == stim.PauliString("iY")
-    p *= stim.PauliString("i_")
-    assert alias == stim.PauliString("-Y")
-    p *= stim.PauliString("i_")
-    assert alias == stim.PauliString("-iY")
+    p *= lestim.PauliString("i_")
+    assert alias == lestim.PauliString("+Y")
+    p *= lestim.PauliString("i_")
+    assert alias == lestim.PauliString("iY")
+    p *= lestim.PauliString("i_")
+    assert alias == lestim.PauliString("-Y")
+    p *= lestim.PauliString("i_")
+    assert alias == lestim.PauliString("-iY")
 
-    p *= stim.PauliString("-i_")
-    assert alias == stim.PauliString("-Y")
-    p *= stim.PauliString("-i_")
-    assert alias == stim.PauliString("iY")
-    p *= stim.PauliString("-i_")
-    assert alias == stim.PauliString("+Y")
-    p *= stim.PauliString("-i_")
-    assert alias == stim.PauliString("-iY")
+    p *= lestim.PauliString("-i_")
+    assert alias == lestim.PauliString("-Y")
+    p *= lestim.PauliString("-i_")
+    assert alias == lestim.PauliString("iY")
+    p *= lestim.PauliString("-i_")
+    assert alias == lestim.PauliString("+Y")
+    p *= lestim.PauliString("-i_")
+    assert alias == lestim.PauliString("-iY")
 
     assert alias is p
 
 
 def test_imaginary_phase():
-    p = stim.PauliString("IXYZ")
-    ip = stim.PauliString("iIXYZ")
-    assert 1j * p == p * 1j == ip == -stim.PauliString("-iIXYZ")
+    p = lestim.PauliString("IXYZ")
+    ip = lestim.PauliString("iIXYZ")
+    assert 1j * p == p * 1j == ip == -lestim.PauliString("-iIXYZ")
     assert p.sign == 1
     assert (-p).sign == -1
     assert ip.sign == 1j
     assert (-ip).sign == -1j
-    assert stim.PauliString("X") * stim.PauliString("Y") == 1j * stim.PauliString("Z")
-    assert stim.PauliString("Y") * stim.PauliString("X") == -1j * stim.PauliString("Z")
+    assert lestim.PauliString("X") * lestim.PauliString("Y") == 1j * lestim.PauliString("Z")
+    assert lestim.PauliString("Y") * lestim.PauliString("X") == -1j * lestim.PauliString("Z")
 
 
 def test_get_set_sign():
-    p = stim.PauliString(2)
+    p = lestim.PauliString(2)
     assert p.sign == +1
     p.sign = -1
     assert str(p) == "-__"
@@ -283,7 +283,7 @@ def test_get_set_sign():
 
 
 def test_get_set_item():
-    p = stim.PauliString(5)
+    p = lestim.PauliString(5)
     assert list(p) == [0, 0, 0, 0, 0]
     assert p[0] == 0
     p[0] = 1
@@ -304,40 +304,40 @@ def test_get_set_item():
 
 
 def test_get_slice():
-    p = stim.PauliString("XXXX__YYYY__ZZZZX")
-    assert p[:7] == stim.PauliString("XXXX__Y")
-    assert p[:-3] == stim.PauliString("XXXX__YYYY__ZZ")
-    assert p[::2] == stim.PauliString("XX_YY_ZZX")
-    assert p[::-1] == stim.PauliString("XZZZZ__YYYY__XXXX")
-    assert p[-3:3] == stim.PauliString("")
-    assert p[-6:-1] == stim.PauliString("_ZZZZ")
-    assert p[3:5:-1] == stim.PauliString("")
-    assert p[5:3:-1] == stim.PauliString("__")
-    assert p[4:2:-1] == stim.PauliString("_X")
-    assert p[2:0:-1] == stim.PauliString("XX")
+    p = lestim.PauliString("XXXX__YYYY__ZZZZX")
+    assert p[:7] == lestim.PauliString("XXXX__Y")
+    assert p[:-3] == lestim.PauliString("XXXX__YYYY__ZZ")
+    assert p[::2] == lestim.PauliString("XX_YY_ZZX")
+    assert p[::-1] == lestim.PauliString("XZZZZ__YYYY__XXXX")
+    assert p[-3:3] == lestim.PauliString("")
+    assert p[-6:-1] == lestim.PauliString("_ZZZZ")
+    assert p[3:5:-1] == lestim.PauliString("")
+    assert p[5:3:-1] == lestim.PauliString("__")
+    assert p[4:2:-1] == lestim.PauliString("_X")
+    assert p[2:0:-1] == lestim.PauliString("XX")
 
 
 def test_copy():
-    p = stim.PauliString(3)
+    p = lestim.PauliString(3)
     p2 = p.copy()
     assert p == p2
     assert p is not p2
 
-    p = stim.PauliString("-i_XYZ")
+    p = lestim.PauliString("-i_XYZ")
     p2 = p.copy()
     assert p == p2
     assert p is not p2
 
 
 def test_hash():
-    # stim.PauliString is mutable. It must not also be value-hashable.
+    # lestim.PauliString is mutable. It must not also be value-hashable.
     # Defining __hash__ requires defining a FrozenPauliString variant instead.
     with pytest.raises(TypeError, match="unhashable"):
-        _ = hash(stim.PauliString(1))
+        _ = hash(lestim.PauliString(1))
 
 
 def test_add():
-    ps = stim.PauliString
+    ps = lestim.PauliString
     assert ps(0) + ps(0) == ps(0)
     assert ps(3) + ps(1000) == ps(1003)
     assert ps(1000) + ps(3) == ps(1003)
@@ -365,7 +365,7 @@ def test_add():
 
 
 def test_mul_different_sizes():
-    ps = stim.PauliString
+    ps = lestim.PauliString
     assert ps("") * ps("X" * 1000) == ps("X" * 1000)
     assert ps("X" * 1000) * ps("") == ps("X" * 1000)
     assert ps("Z" * 1000) * ps("") == ps("Z" * 1000)
@@ -380,29 +380,29 @@ def test_mul_different_sizes():
 
 
 def test_div():
-    assert stim.PauliString("+XYZ") / +1 == stim.PauliString("+XYZ")
-    assert stim.PauliString("+XYZ") / -1 == stim.PauliString("-XYZ")
-    assert stim.PauliString("+XYZ") / 1j == stim.PauliString("-iXYZ")
-    assert stim.PauliString("+XYZ") / -1j == stim.PauliString("iXYZ")
-    assert stim.PauliString("iXYZ") / 1j == stim.PauliString("XYZ")
-    p = stim.PauliString("__")
+    assert lestim.PauliString("+XYZ") / +1 == lestim.PauliString("+XYZ")
+    assert lestim.PauliString("+XYZ") / -1 == lestim.PauliString("-XYZ")
+    assert lestim.PauliString("+XYZ") / 1j == lestim.PauliString("-iXYZ")
+    assert lestim.PauliString("+XYZ") / -1j == lestim.PauliString("iXYZ")
+    assert lestim.PauliString("iXYZ") / 1j == lestim.PauliString("XYZ")
+    p = lestim.PauliString("__")
     alias = p
-    assert p / -1 == stim.PauliString("-__")
-    assert alias == stim.PauliString("__")
+    assert p / -1 == lestim.PauliString("-__")
+    assert alias == lestim.PauliString("__")
     p /= -1
-    assert alias == stim.PauliString("-__")
+    assert alias == lestim.PauliString("-__")
     p /= 1j
-    assert alias == stim.PauliString("i__")
+    assert alias == lestim.PauliString("i__")
     p /= 1j
-    assert alias == stim.PauliString("__")
+    assert alias == lestim.PauliString("__")
     p /= -1j
-    assert alias == stim.PauliString("i__")
+    assert alias == lestim.PauliString("i__")
     p /= 1
-    assert alias == stim.PauliString("i__")
+    assert alias == lestim.PauliString("i__")
 
 
 def test_mul_repeat():
-    ps = stim.PauliString
+    ps = lestim.PauliString
     assert ps("") * 100 == ps("")
     assert ps("X") * 100 == ps("X" * 100)
     assert ps("XYZ_") * 1000 == ps("XYZ_" * 1000)
@@ -444,34 +444,34 @@ def test_mul_repeat():
 
 
 def test_init_list():
-    assert stim.PauliString([]) == stim.PauliString(0)
-    assert stim.PauliString([0, 1, 2, 3]) == stim.PauliString("_XYZ")
+    assert lestim.PauliString([]) == lestim.PauliString(0)
+    assert lestim.PauliString([0, 1, 2, 3]) == lestim.PauliString("_XYZ")
 
     with pytest.raises(ValueError, match="pauli"):
-        _ = stim.PauliString([-1])
+        _ = lestim.PauliString([-1])
     with pytest.raises(ValueError, match="pauli"):
-        _ = stim.PauliString([4])
+        _ = lestim.PauliString([4])
     with pytest.raises(ValueError):
-        _ = stim.PauliString([2**500])
+        _ = lestim.PauliString([2**500])
 
 
 def test_init_copy():
-    p = stim.PauliString("_XYZ")
-    p2 = stim.PauliString(p)
+    p = lestim.PauliString("_XYZ")
+    p2 = lestim.PauliString(p)
     assert p is not p2
     assert p == p2
 
-    p = stim.PauliString("-i_XYZ")
-    p2 = stim.PauliString(p)
+    p = lestim.PauliString("-i_XYZ")
+    p2 = lestim.PauliString(p)
     assert p is not p2
     assert p == p2
 
 
 def test_commutes_different_lengths():
-    x1000 = stim.PauliString("X" * 1000)
-    z1000 = stim.PauliString("Z" * 1000)
-    x1 = stim.PauliString("X")
-    z1 = stim.PauliString("Z")
+    x1000 = lestim.PauliString("X" * 1000)
+    z1000 = lestim.PauliString("Z" * 1000)
+    x1 = lestim.PauliString("X")
+    z1 = lestim.PauliString("Z")
     assert x1.commutes(x1000)
     assert x1000.commutes(x1)
     assert z1.commutes(z1000)
@@ -485,17 +485,17 @@ def test_commutes_different_lengths():
 def test_pickle():
     import pickle
 
-    t = stim.PauliString.random(4)
+    t = lestim.PauliString.random(4)
     a = pickle.dumps(t)
     assert pickle.loads(a) == t
 
-    t = stim.PauliString("i_XYZ")
+    t = lestim.PauliString("i_XYZ")
     a = pickle.dumps(t)
     assert pickle.loads(a) == t
 
 
 def test_to_numpy():
-    p = stim.PauliString("_XYZ___XYXZYZ")
+    p = lestim.PauliString("_XYZ___XYXZYZ")
 
     xs, zs = p.to_numpy()
     assert xs.dtype == np.bool_
@@ -511,144 +511,144 @@ def test_to_numpy():
 
 
 def test_from_numpy():
-    p = stim.PauliString.from_numpy(
+    p = lestim.PauliString.from_numpy(
         xs=np.array([0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0], dtype=np.bool_),
         zs=np.array([0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 1], dtype=np.bool_))
-    assert p == stim.PauliString("_XYZ___XYXZYZ")
+    assert p == lestim.PauliString("_XYZ___XYXZYZ")
 
-    p = stim.PauliString.from_numpy(
+    p = lestim.PauliString.from_numpy(
         xs=np.array([0x86, 0x0B], dtype=np.uint8),
         zs=np.array([0x0C, 0x1D], dtype=np.uint8),
         num_qubits=13)
 
-    assert p == stim.PauliString("_XYZ___XYXZYZ")
-    p = stim.PauliString.from_numpy(
+    assert p == lestim.PauliString("_XYZ___XYXZYZ")
+    p = lestim.PauliString.from_numpy(
         xs=np.array([0x86, 0x0B], dtype=np.uint8),
         zs=np.array([0x0C, 0x1D], dtype=np.uint8),
         num_qubits=15,
         sign=1j)
-    assert p == stim.PauliString("i_XYZ___XYXZYZ__")
+    assert p == lestim.PauliString("i_XYZ___XYXZYZ__")
 
 
 def test_from_numpy_bad_bit_packed_len():
     xs = np.array([0x86, 0x0B], dtype=np.uint8)
     zs = np.array([0x0C, 0x1D], dtype=np.uint8)
     with pytest.raises(ValueError, match="specify expected number"):
-        stim.PauliString.from_numpy(xs=xs, zs=zs)
+        lestim.PauliString.from_numpy(xs=xs, zs=zs)
 
     with pytest.raises(ValueError, match="between 9 and 16 bits"):
-        stim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=100)
+        lestim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=100)
 
     with pytest.raises(ValueError, match="between 9 and 16 bits"):
-        stim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=0)
+        lestim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=0)
 
     with pytest.raises(ValueError, match="between 9 and 16 bits"):
-        stim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=8)
+        lestim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=8)
 
     with pytest.raises(ValueError, match="between 9 and 16 bits"):
-        stim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=17)
+        lestim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=17)
 
     with pytest.raises(ValueError, match="between 0 and 0 bits"):
-        stim.PauliString.from_numpy(xs=xs[:0], zs=zs, num_qubits=9)
+        lestim.PauliString.from_numpy(xs=xs[:0], zs=zs, num_qubits=9)
 
     with pytest.raises(ValueError, match="between 1 and 8 bits"):
-        stim.PauliString.from_numpy(xs=xs[:1], zs=zs, num_qubits=9)
+        lestim.PauliString.from_numpy(xs=xs[:1], zs=zs, num_qubits=9)
 
     with pytest.raises(ValueError, match="between 1 and 8 bits"):
-        stim.PauliString.from_numpy(xs=xs, zs=zs[:1], num_qubits=9)
+        lestim.PauliString.from_numpy(xs=xs, zs=zs[:1], num_qubits=9)
 
     with pytest.raises(ValueError, match="1-dimensional"):
-        stim.PauliString.from_numpy(xs=np.array([xs, xs]), zs=np.array([zs, zs]), num_qubits=9)
+        lestim.PauliString.from_numpy(xs=np.array([xs, xs]), zs=np.array([zs, zs]), num_qubits=9)
 
     with pytest.raises(ValueError, match="uint8"):
-        stim.PauliString.from_numpy(xs=np.array(xs, dtype=np.uint64), zs=np.array(xs, dtype=np.uint64), num_qubits=9)
+        lestim.PauliString.from_numpy(xs=np.array(xs, dtype=np.uint64), zs=np.array(xs, dtype=np.uint64), num_qubits=9)
 
 
 def test_from_numpy_bad_bool_len():
     xs = np.array([0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0], dtype=np.bool_)
     zs = np.array([0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0], dtype=np.bool_)
     with pytest.raises(ValueError, match="shape=13"):
-        stim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=12)
+        lestim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=12)
 
     with pytest.raises(ValueError, match="shape=13"):
-        stim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=14)
+        lestim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=14)
 
     with pytest.raises(ValueError, match="shape=12"):
-        stim.PauliString.from_numpy(xs=xs[:-1], zs=zs, num_qubits=13)
+        lestim.PauliString.from_numpy(xs=xs[:-1], zs=zs, num_qubits=13)
 
     with pytest.raises(ValueError, match="shape=12"):
-        stim.PauliString.from_numpy(xs=xs, zs=zs[:-1], num_qubits=13)
+        lestim.PauliString.from_numpy(xs=xs, zs=zs[:-1], num_qubits=13)
 
     with pytest.raises(ValueError, match="Inconsistent"):
-        stim.PauliString.from_numpy(xs=xs, zs=zs[:-1])
+        lestim.PauliString.from_numpy(xs=xs, zs=zs[:-1])
 
     with pytest.raises(RuntimeError, match="Unable to cast"):
-        stim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=-1)
+        lestim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=-1)
 
 
 @pytest.mark.parametrize("n", [0, 1, 41, 42, 1023, 1024, 1025])
 def test_to_from_numpy_round_trip(n: int):
-    p = stim.PauliString.random(n)
+    p = lestim.PauliString.random(n)
     xs, zs = p.to_numpy()
-    p2 = stim.PauliString.from_numpy(xs=xs, zs=zs, sign=p.sign)
+    p2 = lestim.PauliString.from_numpy(xs=xs, zs=zs, sign=p.sign)
     assert p2 == p
     xs, zs = p.to_numpy(bit_packed=True)
-    p2 = stim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=n, sign=p.sign)
+    p2 = lestim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=n, sign=p.sign)
     assert p2 == p
 
 
 def test_to_unitary_matrix():
     np.testing.assert_array_equal(
-        stim.PauliString("").to_unitary_matrix(endian="little"),
+        lestim.PauliString("").to_unitary_matrix(endian="little"),
         [[1]],
     )
     np.testing.assert_array_equal(
-        stim.PauliString("-").to_unitary_matrix(endian="big"),
+        lestim.PauliString("-").to_unitary_matrix(endian="big"),
         [[-1]],
     )
     np.testing.assert_array_equal(
-        stim.PauliString("i").to_unitary_matrix(endian="big"),
+        lestim.PauliString("i").to_unitary_matrix(endian="big"),
         [[1j]],
     )
     np.testing.assert_array_equal(
-        stim.PauliString("-i").to_unitary_matrix(endian="big"),
+        lestim.PauliString("-i").to_unitary_matrix(endian="big"),
         [[-1j]],
     )
 
     np.testing.assert_array_equal(
-        stim.PauliString("I").to_unitary_matrix(endian="little"),
+        lestim.PauliString("I").to_unitary_matrix(endian="little"),
         [[1, 0], [0, 1]],
     )
     np.testing.assert_array_equal(
-        stim.PauliString("X").to_unitary_matrix(endian="little"),
+        lestim.PauliString("X").to_unitary_matrix(endian="little"),
         [[0, 1], [1, 0]],
     )
     np.testing.assert_array_equal(
-        stim.PauliString("Y").to_unitary_matrix(endian="little"),
+        lestim.PauliString("Y").to_unitary_matrix(endian="little"),
         [[0, -1j], [1j, 0]],
     )
     np.testing.assert_array_equal(
-        stim.PauliString("iY").to_unitary_matrix(endian="little"),
+        lestim.PauliString("iY").to_unitary_matrix(endian="little"),
         [[0, 1], [-1, 0]],
     )
     np.testing.assert_array_equal(
-        stim.PauliString("Z").to_unitary_matrix(endian="little"),
+        lestim.PauliString("Z").to_unitary_matrix(endian="little"),
         [[1, 0], [0, -1]],
     )
     np.testing.assert_array_equal(
-        stim.PauliString("-Z").to_unitary_matrix(endian="little"),
+        lestim.PauliString("-Z").to_unitary_matrix(endian="little"),
         [[-1, 0], [0, 1]],
     )
     np.testing.assert_array_equal(
-        stim.PauliString("YY").to_unitary_matrix(endian="little"),
+        lestim.PauliString("YY").to_unitary_matrix(endian="little"),
         [[0, 0, 0, -1], [0, 0, 1, 0], [0, 1, 0, 0], [-1, 0, 0, 0]],
     )
     np.testing.assert_array_equal(
-        stim.PauliString("-YZ").to_unitary_matrix(endian="little"),
+        lestim.PauliString("-YZ").to_unitary_matrix(endian="little"),
         [[0, 1j, 0, 0], [-1j, 0, 0, 0], [0, 0, 0, -1j], [0, 0, 1j, 0]],
     )
     np.testing.assert_array_equal(
-        stim.PauliString("XYZ").to_unitary_matrix(endian="little"), [
+        lestim.PauliString("XYZ").to_unitary_matrix(endian="little"), [
             [0, 0, 0, -1j, 0, 0, 0, 0],
             [0, 0, -1j, 0, 0, 0, 0, 0],
             [0, 1j, 0, 0, 0, 0, 0, 0],
@@ -659,7 +659,7 @@ def test_to_unitary_matrix():
             [0, 0, 0, 0, -1j, 0, 0, 0],
         ])
     np.testing.assert_array_equal(
-        stim.PauliString("ZYX").to_unitary_matrix(endian="big"), [
+        lestim.PauliString("ZYX").to_unitary_matrix(endian="big"), [
             [0, 0, 0, -1j, 0, 0, 0, 0],
             [0, 0, -1j, 0, 0, 0, 0, 0],
             [0, 1j, 0, 0, 0, 0, 0, 0],
@@ -672,59 +672,59 @@ def test_to_unitary_matrix():
 
 
 def test_from_unitary_matrix():
-    assert stim.PauliString.from_unitary_matrix(
+    assert lestim.PauliString.from_unitary_matrix(
         [[1]]
-    ) == stim.PauliString("")
-    assert stim.PauliString.from_unitary_matrix(
+    ) == lestim.PauliString("")
+    assert lestim.PauliString.from_unitary_matrix(
         [[-1]]
-    ) == stim.PauliString("-")
-    assert stim.PauliString.from_unitary_matrix(
+    ) == lestim.PauliString("-")
+    assert lestim.PauliString.from_unitary_matrix(
         [[1j]]
-    ) == stim.PauliString("i")
-    assert stim.PauliString.from_unitary_matrix(
+    ) == lestim.PauliString("i")
+    assert lestim.PauliString.from_unitary_matrix(
         [[-1j]]
-    ) == stim.PauliString("-i")
+    ) == lestim.PauliString("-i")
 
-    assert stim.PauliString.from_unitary_matrix(
+    assert lestim.PauliString.from_unitary_matrix(
         [[1, 0], [0, 1]]
-    ) == stim.PauliString("I")
-    assert stim.PauliString.from_unitary_matrix(
+    ) == lestim.PauliString("I")
+    assert lestim.PauliString.from_unitary_matrix(
         [[0, 1], [1, 0]]
-    ) == stim.PauliString("X")
-    assert stim.PauliString.from_unitary_matrix(
+    ) == lestim.PauliString("X")
+    assert lestim.PauliString.from_unitary_matrix(
         [[0, -1j], [1j, 0]]
-    ) == stim.PauliString("Y")
-    assert stim.PauliString.from_unitary_matrix(
+    ) == lestim.PauliString("Y")
+    assert lestim.PauliString.from_unitary_matrix(
         [[1, 0], [0, -1]]
-    ) == stim.PauliString("Z")
+    ) == lestim.PauliString("Z")
 
-    assert stim.PauliString.from_unitary_matrix(
+    assert lestim.PauliString.from_unitary_matrix(
         [[0, 1], [-1, 0]]
-    ) == stim.PauliString("iY")
-    assert stim.PauliString.from_unitary_matrix(
+    ) == lestim.PauliString("iY")
+    assert lestim.PauliString.from_unitary_matrix(
         [[0, 1j], [-1j, 0]]
-    ) == stim.PauliString("-Y")
-    assert stim.PauliString.from_unitary_matrix(
+    ) == lestim.PauliString("-Y")
+    assert lestim.PauliString.from_unitary_matrix(
         [[1j, 0], [0, -1j]]
-    ) == stim.PauliString("iZ")
-    assert stim.PauliString.from_unitary_matrix(
+    ) == lestim.PauliString("iZ")
+    assert lestim.PauliString.from_unitary_matrix(
         [[-1, 0], [0, 1]]
-    ) == stim.PauliString("-Z")
+    ) == lestim.PauliString("-Z")
 
-    assert stim.PauliString.from_unitary_matrix(
+    assert lestim.PauliString.from_unitary_matrix(
         [[1]], unsigned=True
-    ) == stim.PauliString("")
-    assert stim.PauliString.from_unitary_matrix(
+    ) == lestim.PauliString("")
+    assert lestim.PauliString.from_unitary_matrix(
         [[-1]], unsigned=True
-    ) == stim.PauliString("")
-    assert stim.PauliString.from_unitary_matrix(
+    ) == lestim.PauliString("")
+    assert lestim.PauliString.from_unitary_matrix(
         [[0, 1], [-1, 0]], unsigned=True
-    ) == stim.PauliString("Y")
-    assert stim.PauliString.from_unitary_matrix(
+    ) == lestim.PauliString("Y")
+    assert lestim.PauliString.from_unitary_matrix(
         [[0, +1 * 1j**0.1], [-1 * 1j**0.1, 0]], unsigned=True
-    ) == stim.PauliString("Y")
+    ) == lestim.PauliString("Y")
 
-    assert stim.PauliString.from_unitary_matrix([
+    assert lestim.PauliString.from_unitary_matrix([
         [0, 0, 0, -1j, 0, 0, 0, 0],
         [0, 0, -1j, 0, 0, 0, 0, 0],
         [0, 1j, 0, 0, 0, 0, 0, 0],
@@ -733,8 +733,8 @@ def test_from_unitary_matrix():
         [0, 0, 0, 0, 0, 0, 1j, 0],
         [0, 0, 0, 0, 0, -1j, 0, 0],
         [0, 0, 0, 0, -1j, 0, 0, 0],
-    ], endian="little") == stim.PauliString("XYZ")
-    assert stim.PauliString.from_unitary_matrix([
+    ], endian="little") == lestim.PauliString("XYZ")
+    assert lestim.PauliString.from_unitary_matrix([
         [0, 0, 0, -1j, 0, 0, 0, 0],
         [0, 0, -1j, 0, 0, 0, 0, 0],
         [0, 1j, 0, 0, 0, 0, 0, 0],
@@ -743,8 +743,8 @@ def test_from_unitary_matrix():
         [0, 0, 0, 0, 0, 0, 1j, 0],
         [0, 0, 0, 0, 0, -1j, 0, 0],
         [0, 0, 0, 0, -1j, 0, 0, 0],
-    ], endian="big") == stim.PauliString("ZYX")
-    assert stim.PauliString.from_unitary_matrix(np.array([
+    ], endian="big") == lestim.PauliString("ZYX")
+    assert lestim.PauliString.from_unitary_matrix(np.array([
         [0, 0, 0, -1j, 0, 0, 0, 0],
         [0, 0, -1j, 0, 0, 0, 0, 0],
         [0, 1j, 0, 0, 0, 0, 0, 0],
@@ -753,8 +753,8 @@ def test_from_unitary_matrix():
         [0, 0, 0, 0, 0, 0, 1j, 0],
         [0, 0, 0, 0, 0, -1j, 0, 0],
         [0, 0, 0, 0, -1j, 0, 0, 0],
-    ]) * 1j**0.1, endian="big", unsigned=True) == stim.PauliString("ZYX")
-    assert stim.PauliString.from_unitary_matrix(np.array([
+    ]) * 1j**0.1, endian="big", unsigned=True) == lestim.PauliString("ZYX")
+    assert lestim.PauliString.from_unitary_matrix(np.array([
         [0, 0, 0, -1j, 0, 0, 0, 0],
         [0, 0, -1j, 0, 0, 0, 0, 0],
         [0, 1j, 0, 0, 0, 0, 0, 0],
@@ -763,53 +763,53 @@ def test_from_unitary_matrix():
         [0, 0, 0, 0, 0, 0, 1j, 0],
         [0, 0, 0, 0, 0, -1j, 0, 0],
         [0, 0, 0, 0, -1j, 0, 0, 0],
-    ]) * -1, endian="big", unsigned=True) == stim.PauliString("ZYX")
+    ]) * -1, endian="big", unsigned=True) == lestim.PauliString("ZYX")
 
 
 def test_from_unitary_matrix_detect_bad_matrix():
     with pytest.raises(ValueError, match="power of 2"):
-        stim.PauliString.from_unitary_matrix([])
+        lestim.PauliString.from_unitary_matrix([])
     with pytest.raises(ValueError, match="row with no non-zero"):
-        stim.PauliString.from_unitary_matrix([[]])
+        lestim.PauliString.from_unitary_matrix([[]])
     with pytest.raises(ValueError, match="row with no non-zero"):
-        stim.PauliString.from_unitary_matrix([[0]])
+        lestim.PauliString.from_unitary_matrix([[0]])
     with pytest.raises(ValueError, match="values besides 0, 1,"):
-        stim.PauliString.from_unitary_matrix([[0.5]])
+        lestim.PauliString.from_unitary_matrix([[0.5]])
     with pytest.raises(ValueError, match="isn't square"):
-        stim.PauliString.from_unitary_matrix([[1, 0]])
+        lestim.PauliString.from_unitary_matrix([[1, 0]])
     with pytest.raises(ValueError, match="no non-zero entries"):
-        stim.PauliString.from_unitary_matrix([[1], [0]])
+        lestim.PauliString.from_unitary_matrix([[1], [0]])
     with pytest.raises(ValueError, match="different lengths"):
-        stim.PauliString.from_unitary_matrix([[0, 1], [1]])
+        lestim.PauliString.from_unitary_matrix([[0, 1], [1]])
     with pytest.raises(ValueError, match="two non-zero entries"):
-        stim.PauliString.from_unitary_matrix([[1, 1],
+        lestim.PauliString.from_unitary_matrix([[1, 1],
                                               [0, 1]])
     with pytest.raises(ValueError, match="which qubits are flipped"):
-        stim.PauliString.from_unitary_matrix([[1, 0],
+        lestim.PauliString.from_unitary_matrix([[1, 0],
                                               [1, 0]])
     with pytest.raises(ValueError, match="isn't square"):
-        stim.PauliString.from_unitary_matrix([[1, 0, 0],
+        lestim.PauliString.from_unitary_matrix([[1, 0, 0],
                                               [0, 1, 0]])
     with pytest.raises(ValueError, match="consistent phase flips"):
-        stim.PauliString.from_unitary_matrix([[1, 0],
+        lestim.PauliString.from_unitary_matrix([[1, 0],
                                               [0, 1j]])
 
     with pytest.raises(ValueError, match="power of 2"):
-        stim.PauliString.from_unitary_matrix([[1, 0, 0],
+        lestim.PauliString.from_unitary_matrix([[1, 0, 0],
                                               [0, 1, 0],
                                               [0, 0, 1]])
     with pytest.raises(ValueError, match="which qubits are flipped"):
-        stim.PauliString.from_unitary_matrix([[1, 0, 0, 0],
+        lestim.PauliString.from_unitary_matrix([[1, 0, 0, 0],
                                               [0, 1, 0, 0],
                                               [0, 0, 0, 1],
                                               [0, 0, 1, 0]])
     with pytest.raises(ValueError, match="consistent phase flips"):
-        stim.PauliString.from_unitary_matrix([[1, 0, 0, 0],
+        lestim.PauliString.from_unitary_matrix([[1, 0, 0, 0],
                                               [0, 1, 0, 0],
                                               [0, 0, 1, 0],
                                               [0, 0, 0, -1]])
     with pytest.raises(ValueError, match="consistent phase flips"):
-        stim.PauliString.from_unitary_matrix([[1, 0, 0, 0],
+        lestim.PauliString.from_unitary_matrix([[1, 0, 0, 0],
                                               [0, 1, 0, 0],
                                               [0, 0, -1, 0],
                                               [0, 0, 0, 1]])
@@ -817,64 +817,64 @@ def test_from_unitary_matrix_detect_bad_matrix():
 
 @pytest.mark.parametrize("n,endian", itertools.product(range(8), ['little', 'big']))
 def test_fuzz_to_from_unitary_matrix(n: int, endian: str):
-    p = stim.PauliString.random(n, allow_imaginary=True)
+    p = lestim.PauliString.random(n, allow_imaginary=True)
     u = p.to_unitary_matrix(endian=endian)
-    r = stim.PauliString.from_unitary_matrix(u, endian=endian)
+    r = lestim.PauliString.from_unitary_matrix(u, endian=endian)
     assert p == r
 
-    via_tableau = stim.Tableau.from_unitary_matrix(u, endian=endian).to_pauli_string()
+    via_tableau = lestim.Tableau.from_unitary_matrix(u, endian=endian).to_pauli_string()
     r.sign = +1
     assert via_tableau == r
 
 
 def test_before_after():
-    before = stim.PauliString("XXXYYYZZZ")
-    after = stim.PauliString("XYXYZYXZZ")
-    assert before.after(stim.Circuit("C_XYZ 1 4 6")) == after
-    assert before.after(stim.Circuit("C_XYZ 1 4 6")[0]) == after
-    assert before.after(stim.Tableau.from_named_gate("C_XYZ"), targets=[1, 4, 6]) == after
-    assert after.before(stim.Circuit("C_XYZ 1 4 6")) == before
-    assert after.before(stim.Circuit("C_XYZ 1 4 6")[0]) == before
-    assert after.before(stim.Tableau.from_named_gate("C_XYZ"), targets=[1, 4, 6]) == before
+    before = lestim.PauliString("XXXYYYZZZ")
+    after = lestim.PauliString("XYXYZYXZZ")
+    assert before.after(lestim.Circuit("C_XYZ 1 4 6")) == after
+    assert before.after(lestim.Circuit("C_XYZ 1 4 6")[0]) == after
+    assert before.after(lestim.Tableau.from_named_gate("C_XYZ"), targets=[1, 4, 6]) == after
+    assert after.before(lestim.Circuit("C_XYZ 1 4 6")) == before
+    assert after.before(lestim.Circuit("C_XYZ 1 4 6")[0]) == before
+    assert after.before(lestim.Tableau.from_named_gate("C_XYZ"), targets=[1, 4, 6]) == before
 
 
 def test_iter_small():
-    assert list(stim.PauliString.iter_all(0)) == [stim.PauliString(0)]
-    assert list(stim.PauliString.iter_all(1)) == [
-        stim.PauliString("_"),
-        stim.PauliString("X"),
-        stim.PauliString("Y"),
-        stim.PauliString("Z"),
+    assert list(lestim.PauliString.iter_all(0)) == [lestim.PauliString(0)]
+    assert list(lestim.PauliString.iter_all(1)) == [
+        lestim.PauliString("_"),
+        lestim.PauliString("X"),
+        lestim.PauliString("Y"),
+        lestim.PauliString("Z"),
     ]
-    assert list(stim.PauliString.iter_all(1, max_weight=-1)) == [
+    assert list(lestim.PauliString.iter_all(1, max_weight=-1)) == [
     ]
-    assert list(stim.PauliString.iter_all(1, max_weight=0)) == [
-        stim.PauliString("_"),
+    assert list(lestim.PauliString.iter_all(1, max_weight=0)) == [
+        lestim.PauliString("_"),
     ]
-    assert list(stim.PauliString.iter_all(1, max_weight=1)) == [
-        stim.PauliString("_"),
-        stim.PauliString("X"),
-        stim.PauliString("Y"),
-        stim.PauliString("Z"),
+    assert list(lestim.PauliString.iter_all(1, max_weight=1)) == [
+        lestim.PauliString("_"),
+        lestim.PauliString("X"),
+        lestim.PauliString("Y"),
+        lestim.PauliString("Z"),
     ]
-    assert list(stim.PauliString.iter_all(1, min_weight=1, max_weight=1)) == [
-        stim.PauliString("X"),
-        stim.PauliString("Y"),
-        stim.PauliString("Z"),
+    assert list(lestim.PauliString.iter_all(1, min_weight=1, max_weight=1)) == [
+        lestim.PauliString("X"),
+        lestim.PauliString("Y"),
+        lestim.PauliString("Z"),
     ]
-    assert list(stim.PauliString.iter_all(2, min_weight=1, max_weight=1, allowed_paulis="XY")) == [
-        stim.PauliString("X_"),
-        stim.PauliString("Y_"),
-        stim.PauliString("_X"),
-        stim.PauliString("_Y"),
+    assert list(lestim.PauliString.iter_all(2, min_weight=1, max_weight=1, allowed_paulis="XY")) == [
+        lestim.PauliString("X_"),
+        lestim.PauliString("Y_"),
+        lestim.PauliString("_X"),
+        lestim.PauliString("_Y"),
     ]
 
     with pytest.raises(ValueError, match="characters other than"):
-        stim.PauliString.iter_all(2, allowed_paulis="A")
+        lestim.PauliString.iter_all(2, allowed_paulis="A")
 
 
 def test_iter_reusable():
-    v = stim.PauliString.iter_all(2)
+    v = lestim.PauliString.iter_all(2)
     vs1 = list(v)
     vs2 = list(v)
     assert vs1 == vs2
@@ -882,163 +882,163 @@ def test_iter_reusable():
 
 
 def test_backwards_compatibility_init():
-    assert stim.PauliString() == stim.PauliString("+")
-    assert stim.PauliString(5) == stim.PauliString("+_____")
-    assert stim.PauliString([1, 2, 3]) == stim.PauliString("+XYZ")
-    assert stim.PauliString("XYZ") == stim.PauliString("+XYZ")
-    assert stim.PauliString(stim.PauliString("XYZ")) == stim.PauliString("+XYZ")
-    assert stim.PauliString("X" for _ in range(4)) == stim.PauliString("+XXXX")
+    assert lestim.PauliString() == lestim.PauliString("+")
+    assert lestim.PauliString(5) == lestim.PauliString("+_____")
+    assert lestim.PauliString([1, 2, 3]) == lestim.PauliString("+XYZ")
+    assert lestim.PauliString("XYZ") == lestim.PauliString("+XYZ")
+    assert lestim.PauliString(lestim.PauliString("XYZ")) == lestim.PauliString("+XYZ")
+    assert lestim.PauliString("X" for _ in range(4)) == lestim.PauliString("+XXXX")
 
     # These keywords have been removed from the documentation and the .pyi, but
     # their functionality needs to be maintained for backwards compatibility.
     # noinspection PyArgumentList
-    assert stim.PauliString(num_qubits=5) == stim.PauliString("+_____")
+    assert lestim.PauliString(num_qubits=5) == lestim.PauliString("+_____")
     # noinspection PyArgumentList
-    assert stim.PauliString(pauli_indices=[1, 2, 3]) == stim.PauliString("+XYZ")
+    assert lestim.PauliString(pauli_indices=[1, 2, 3]) == lestim.PauliString("+XYZ")
     # noinspection PyArgumentList
-    assert stim.PauliString(text="XYZ") == stim.PauliString("+XYZ")
+    assert lestim.PauliString(text="XYZ") == lestim.PauliString("+XYZ")
     # noinspection PyArgumentList
-    assert stim.PauliString(other=stim.PauliString("XYZ")) == stim.PauliString("+XYZ")
+    assert lestim.PauliString(other=lestim.PauliString("XYZ")) == lestim.PauliString("+XYZ")
 
 
 def test_pauli_indices():
-    assert stim.PauliString().pauli_indices() == []
-    assert stim.PauliString().pauli_indices("X") == []
-    assert stim.PauliString().pauli_indices("I") == []
-    assert stim.PauliString(5).pauli_indices() == []
-    assert stim.PauliString(5).pauli_indices("X") == []
-    assert stim.PauliString(5).pauli_indices("I") == [0, 1, 2, 3, 4]
-    assert stim.PauliString("X1000").pauli_indices() == [1000]
-    assert stim.PauliString("Y1000").pauli_indices() == [1000]
-    assert stim.PauliString("Z1000").pauli_indices() == [1000]
-    assert stim.PauliString("X1000").pauli_indices("YZ") == []
-    assert stim.PauliString("Y1000").pauli_indices("XZ") == []
-    assert stim.PauliString("Z1000").pauli_indices("XY") == []
-    assert stim.PauliString("X1000").pauli_indices("X") == [1000]
-    assert stim.PauliString("Y1000").pauli_indices("Y") == [1000]
-    assert stim.PauliString("Z1000").pauli_indices("Z") == [1000]
+    assert lestim.PauliString().pauli_indices() == []
+    assert lestim.PauliString().pauli_indices("X") == []
+    assert lestim.PauliString().pauli_indices("I") == []
+    assert lestim.PauliString(5).pauli_indices() == []
+    assert lestim.PauliString(5).pauli_indices("X") == []
+    assert lestim.PauliString(5).pauli_indices("I") == [0, 1, 2, 3, 4]
+    assert lestim.PauliString("X1000").pauli_indices() == [1000]
+    assert lestim.PauliString("Y1000").pauli_indices() == [1000]
+    assert lestim.PauliString("Z1000").pauli_indices() == [1000]
+    assert lestim.PauliString("X1000").pauli_indices("YZ") == []
+    assert lestim.PauliString("Y1000").pauli_indices("XZ") == []
+    assert lestim.PauliString("Z1000").pauli_indices("XY") == []
+    assert lestim.PauliString("X1000").pauli_indices("X") == [1000]
+    assert lestim.PauliString("Y1000").pauli_indices("Y") == [1000]
+    assert lestim.PauliString("Z1000").pauli_indices("Z") == [1000]
 
-    assert stim.PauliString("_XYZ").pauli_indices("x") == [1]
-    assert stim.PauliString("_XYZ").pauli_indices("X") == [1]
-    assert stim.PauliString("_XYZ").pauli_indices("y") == [2]
-    assert stim.PauliString("_XYZ").pauli_indices("Y") == [2]
-    assert stim.PauliString("_XYZ").pauli_indices("z") == [3]
-    assert stim.PauliString("_XYZ").pauli_indices("Z") == [3]
-    assert stim.PauliString("_XYZ").pauli_indices("I") == [0]
-    assert stim.PauliString("_XYZ").pauli_indices("_") == [0]
+    assert lestim.PauliString("_XYZ").pauli_indices("x") == [1]
+    assert lestim.PauliString("_XYZ").pauli_indices("X") == [1]
+    assert lestim.PauliString("_XYZ").pauli_indices("y") == [2]
+    assert lestim.PauliString("_XYZ").pauli_indices("Y") == [2]
+    assert lestim.PauliString("_XYZ").pauli_indices("z") == [3]
+    assert lestim.PauliString("_XYZ").pauli_indices("Z") == [3]
+    assert lestim.PauliString("_XYZ").pauli_indices("I") == [0]
+    assert lestim.PauliString("_XYZ").pauli_indices("_") == [0]
     with pytest.raises(ValueError, match="Invalid character"):
-        assert stim.PauliString("_XYZ").pauli_indices("k")
+        assert lestim.PauliString("_XYZ").pauli_indices("k")
 
 
 def test_before_reset():
-    assert stim.PauliString("Z").before(stim.Circuit("R 0")) == stim.PauliString("_")
-    assert stim.PauliString("Z").before(stim.Circuit("MR 0")) == stim.PauliString("_")
-    assert stim.PauliString("Z").before(stim.Circuit("M 0")) == stim.PauliString("Z")
+    assert lestim.PauliString("Z").before(lestim.Circuit("R 0")) == lestim.PauliString("_")
+    assert lestim.PauliString("Z").before(lestim.Circuit("MR 0")) == lestim.PauliString("_")
+    assert lestim.PauliString("Z").before(lestim.Circuit("M 0")) == lestim.PauliString("Z")
 
-    assert stim.PauliString("X").before(stim.Circuit("RX 0")) == stim.PauliString("_")
-    assert stim.PauliString("X").before(stim.Circuit("MRX 0")) == stim.PauliString("_")
-    assert stim.PauliString("X").before(stim.Circuit("MX 0")) == stim.PauliString("X")
+    assert lestim.PauliString("X").before(lestim.Circuit("RX 0")) == lestim.PauliString("_")
+    assert lestim.PauliString("X").before(lestim.Circuit("MRX 0")) == lestim.PauliString("_")
+    assert lestim.PauliString("X").before(lestim.Circuit("MX 0")) == lestim.PauliString("X")
 
-    assert stim.PauliString("Y").before(stim.Circuit("RY 0")) == stim.PauliString("_")
-    assert stim.PauliString("Y").before(stim.Circuit("MRY 0")) == stim.PauliString("_")
-    assert stim.PauliString("Y").before(stim.Circuit("MY 0")) == stim.PauliString("Y")
+    assert lestim.PauliString("Y").before(lestim.Circuit("RY 0")) == lestim.PauliString("_")
+    assert lestim.PauliString("Y").before(lestim.Circuit("MRY 0")) == lestim.PauliString("_")
+    assert lestim.PauliString("Y").before(lestim.Circuit("MY 0")) == lestim.PauliString("Y")
 
     with pytest.raises(ValueError):
-        stim.PauliString("Z").before(stim.Circuit("RX 0"))
+        lestim.PauliString("Z").before(lestim.Circuit("RX 0"))
     with pytest.raises(ValueError):
-        stim.PauliString("Z").before(stim.Circuit("RY 0"))
+        lestim.PauliString("Z").before(lestim.Circuit("RY 0"))
     with pytest.raises(ValueError):
-        stim.PauliString("Z").before(stim.Circuit("MRX 0"))
+        lestim.PauliString("Z").before(lestim.Circuit("MRX 0"))
     with pytest.raises(ValueError):
-        stim.PauliString("Z").before(stim.Circuit("MRY 0"))
+        lestim.PauliString("Z").before(lestim.Circuit("MRY 0"))
     with pytest.raises(ValueError):
-        stim.PauliString("Z").before(stim.Circuit("MX 0"))
+        lestim.PauliString("Z").before(lestim.Circuit("MX 0"))
     with pytest.raises(ValueError):
-        stim.PauliString("Z").before(stim.Circuit("MY 0"))
+        lestim.PauliString("Z").before(lestim.Circuit("MY 0"))
 
 def test_constructor_from_dict():
     # Values are single Pauli -> Key is the qubit index:
-    assert stim.PauliString({2: "X", 4: "Z"}) == stim.PauliString("__X_Z")
-    assert stim.PauliString({0: 1, 1: 2}) == stim.PauliString("XY")
-    assert stim.PauliString({1: 1, 3: 2, 5: "Z"}) == stim.PauliString("_X_Y_Z")
-    assert stim.PauliString({1: 0, 3: "I", 4: "_"}) == stim.PauliString("_____")
-    assert stim.PauliString({0: "X", 2: "x", 4: "y"}) == stim.PauliString("X_X_Y") # Case-insensitive
-    assert stim.PauliString({}) == stim.PauliString("")
+    assert lestim.PauliString({2: "X", 4: "Z"}) == lestim.PauliString("__X_Z")
+    assert lestim.PauliString({0: 1, 1: 2}) == lestim.PauliString("XY")
+    assert lestim.PauliString({1: 1, 3: 2, 5: "Z"}) == lestim.PauliString("_X_Y_Z")
+    assert lestim.PauliString({1: 0, 3: "I", 4: "_"}) == lestim.PauliString("_____")
+    assert lestim.PauliString({0: "X", 2: "x", 4: "y"}) == lestim.PauliString("X_X_Y") # Case-insensitive
+    assert lestim.PauliString({}) == lestim.PauliString("")
 
     # Values are iterable -> Key is the Pauli:
-    assert stim.PauliString({"X": [0], "Z": [1]}) == stim.PauliString("XZ")
-    assert stim.PauliString({1: [0], 3: [1]}) == stim.PauliString("XZ")
-    assert stim.PauliString({"X": [2], "Z": [4], "Y": [6], "I": [5]}) == stim.PauliString("__X_Z_Y")
-    assert stim.PauliString({"X": [0], "Z": [1,2]}) == stim.PauliString("XZZ")
-    assert stim.PauliString({"x": [0,2], "Y": [4]}) == stim.PauliString("X_X_Y") # Case-insensitive
-    assert stim.PauliString({"I": [1,2]}) == stim.PauliString("___")
-    assert stim.PauliString({"I": []}) == stim.PauliString("")
-    assert stim.PauliString({"I": [9]}) == stim.PauliString(10)
-    assert stim.PauliString({0: [9]}) == stim.PauliString(10)
-    assert stim.PauliString({"_": [9]}) == stim.PauliString(10)
+    assert lestim.PauliString({"X": [0], "Z": [1]}) == lestim.PauliString("XZ")
+    assert lestim.PauliString({1: [0], 3: [1]}) == lestim.PauliString("XZ")
+    assert lestim.PauliString({"X": [2], "Z": [4], "Y": [6], "I": [5]}) == lestim.PauliString("__X_Z_Y")
+    assert lestim.PauliString({"X": [0], "Z": [1,2]}) == lestim.PauliString("XZZ")
+    assert lestim.PauliString({"x": [0,2], "Y": [4]}) == lestim.PauliString("X_X_Y") # Case-insensitive
+    assert lestim.PauliString({"I": [1,2]}) == lestim.PauliString("___")
+    assert lestim.PauliString({"I": []}) == lestim.PauliString("")
+    assert lestim.PauliString({"I": [9]}) == lestim.PauliString(10)
+    assert lestim.PauliString({0: [9]}) == lestim.PauliString(10)
+    assert lestim.PauliString({"_": [9]}) == lestim.PauliString(10)
 
     # Acceptable collisions:
-    assert stim.PauliString({"X": [2], "I": [2]}) == stim.PauliString("__X") # Trivial Pauli should not cause a conflict
-    assert stim.PauliString({"X": [2], 1: [2]}) == stim.PauliString("__X") # Same Pauli should not cause conflict between int/str
-    assert stim.PauliString({"X": [2], "I": [0,1,2,3], "Z": [0], 0: [0,1,2,3], "Y": [1], "_": [0,1,2,3]}) == stim.PauliString("ZYX_") # A more complex example
+    assert lestim.PauliString({"X": [2], "I": [2]}) == lestim.PauliString("__X") # Trivial Pauli should not cause a conflict
+    assert lestim.PauliString({"X": [2], 1: [2]}) == lestim.PauliString("__X") # Same Pauli should not cause conflict between int/str
+    assert lestim.PauliString({"X": [2], "I": [0,1,2,3], "Z": [0], 0: [0,1,2,3], "Y": [1], "_": [0,1,2,3]}) == lestim.PauliString("ZYX_") # A more complex example
 
 def test_constructor_from_dict_errors():
     with pytest.raises(ValueError, match="keys must all be ints"):
-        stim.PauliString({"X": 0}) # When value is non-itetable, key must be int (index)
+        lestim.PauliString({"X": 0}) # When value is non-itetable, key must be int (index)
 
     with pytest.raises(ValueError, match="Don't know how to convert"):
-        stim.PauliString({"A": [0]})
+        lestim.PauliString({"A": [0]})
 
     with pytest.raises(ValueError, match="Don't know how to convert"):
-        stim.PauliString({0: "A"})
+        lestim.PauliString({0: "A"})
 
     with pytest.raises(ValueError, match="Don't know how to convert"):
-        stim.PauliString({0: 4}) # Paulis correspond to 0-3
+        lestim.PauliString({0: 4}) # Paulis correspond to 0-3
 
     with pytest.raises(ValueError, match="Don't know how to convert"):
-        stim.PauliString({0: -1}) # Paulis correspond to 0-3
+        lestim.PauliString({0: -1}) # Paulis correspond to 0-3
 
     with pytest.raises(ValueError, match="Don't know how to convert"):
-        stim.PauliString({"ZX": [0]}) # Paulis need to be single characters
+        lestim.PauliString({"ZX": [0]}) # Paulis need to be single characters
 
     with pytest.raises(ValueError, match="Pauli keys with iterable values"):
-        stim.PauliString({"X": "not an iterable"})
+        lestim.PauliString({"X": "not an iterable"})
 
     with pytest.raises(ValueError, match="Qubit index must be an int"):
-        stim.PauliString({"Y": [0, "not an int"]})
+        lestim.PauliString({"Y": [0, "not an int"]})
 
     with pytest.raises(ValueError, match="keys must all be ints"):
-        stim.PauliString({"X": 0, 1: "Y"})
+        lestim.PauliString({"X": 0, 1: "Y"})
 
     with pytest.raises(ValueError, match="Qubit index must be an int"):
-        stim.PauliString({"X": [0], 1: "Y"})
+        lestim.PauliString({"X": [0], 1: "Y"})
 
     with pytest.raises(ValueError, match="Qubit index must be an int"):
-        stim.PauliString({"X": [0], 1: ["Y"]})
+        lestim.PauliString({"X": [0], 1: ["Y"]})
 
     with pytest.raises(ValueError, match="same qubit index"):
-        stim.PauliString({"X": [0], "Y": [0]}) # Different non-trivial Paulies can't use the same index
+        lestim.PauliString({"X": [0], "Y": [0]}) # Different non-trivial Paulies can't use the same index
 
     with pytest.raises(ValueError, match="same qubit index"):
-        stim.PauliString({"Z": [1], "Y": [4,1]}) # Different non-trivial Paulies can't use the same index
+        lestim.PauliString({"Z": [1], "Y": [4,1]}) # Different non-trivial Paulies can't use the same index
 
     with pytest.raises(ValueError, match="same qubit index"):
-        stim.PauliString({"I": [0,1,4], "Z": [1], "Y": [4,1]}) # Different non-trivial Paulies can't use the same index
+        lestim.PauliString({"I": [0,1,4], "Z": [1], "Y": [4,1]}) # Different non-trivial Paulies can't use the same index
 
     with pytest.raises(ValueError, match="keys must all be ints"):
-        stim.PauliString({(): []})
+        lestim.PauliString({(): []})
 
     with pytest.raises(ValueError, match="keys must all be ints"):
-        stim.PauliString({(): 0})
+        lestim.PauliString({(): 0})
 
     with pytest.raises(ValueError, match="Qubit index must be an int"):
-        stim.PauliString({"X": [()]})
+        lestim.PauliString({"X": [()]})
 
     with pytest.raises(ValueError, match="Qubit index must be non-negative"):
-        stim.PauliString({"X": [-1]})
+        lestim.PauliString({"X": [-1]})
 
     with pytest.raises(ValueError, match="Qubit index must be non-negative"):
-        stim.PauliString({-1: "X"})
+        lestim.PauliString({-1: "X"})
     
     with pytest.raises(ValueError, match="Qubit index must be non-negative"):
-        stim.PauliString({"I": [-1]})
+        lestim.PauliString({"I": [-1]})

--- a/src/stim/util_top/circuit_flow_generators_test.py
+++ b/src/stim/util_top/circuit_flow_generators_test.py
@@ -1,135 +1,135 @@
-import stim
+import lestim
 
 
 def test_solve_flow_measurements():
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         M 2
     """).solve_flow_measurements([
-        stim.Flow("X2 -> X2"),
+        lestim.Flow("X2 -> X2"),
     ]) == [None]
 
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         M 2
     """).solve_flow_measurements([
-        stim.Flow("X2 -> X2"),
-        stim.Flow("Y2 -> Y2"),
-        stim.Flow("Z2 -> Z2"),
-        stim.Flow("Z2 -> 1"),
+        lestim.Flow("X2 -> X2"),
+        lestim.Flow("Y2 -> Y2"),
+        lestim.Flow("Z2 -> Z2"),
+        lestim.Flow("Z2 -> 1"),
     ]) == [None, None, [], [0]]
 
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         MXX 0 1
     """).solve_flow_measurements([
-        stim.Flow("YY -> ZZ"),
-        stim.Flow("YY -> YY"),
-        stim.Flow("YZ -> ZY"),
+        lestim.Flow("YY -> ZZ"),
+        lestim.Flow("YY -> YY"),
+        lestim.Flow("YZ -> ZY"),
     ]) == [[0], [], [0]]
 
 
 def test_solve_flow_generators_measurements_multi_target():
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         M 1 2
     """).flow_generators() == [
-        stim.Flow("1 -> __Z xor rec[1]"),
-        stim.Flow("1 -> _Z_ xor rec[0]"),
-        stim.Flow("__Z -> rec[1]"),
-        stim.Flow("_Z_ -> rec[0]"),
-        stim.Flow("X__ -> X__"),
-        stim.Flow("Z__ -> Z__"),
+        lestim.Flow("1 -> __Z xor rec[1]"),
+        lestim.Flow("1 -> _Z_ xor rec[0]"),
+        lestim.Flow("__Z -> rec[1]"),
+        lestim.Flow("_Z_ -> rec[0]"),
+        lestim.Flow("X__ -> X__"),
+        lestim.Flow("Z__ -> Z__"),
     ]
 
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         MX 1 2
     """).flow_generators() == [
-        stim.Flow("1 -> __X xor rec[1]"),
-        stim.Flow("1 -> _X_ xor rec[0]"),
-        stim.Flow("__X -> rec[1]"),
-        stim.Flow("_X_ -> rec[0]"),
-        stim.Flow("X__ -> X__"),
-        stim.Flow("Z__ -> Z__"),
+        lestim.Flow("1 -> __X xor rec[1]"),
+        lestim.Flow("1 -> _X_ xor rec[0]"),
+        lestim.Flow("__X -> rec[1]"),
+        lestim.Flow("_X_ -> rec[0]"),
+        lestim.Flow("X__ -> X__"),
+        lestim.Flow("Z__ -> Z__"),
     ]
 
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         MYY 1 2 3 4
     """).flow_generators() == [
-        stim.Flow("1 -> ___YY xor rec[1]"),
-        stim.Flow("1 -> _YY__ xor rec[0]"),
-        stim.Flow("____Y -> ____Y"),
-        stim.Flow("___XZ -> ___ZX xor rec[1]"),
-        stim.Flow("___ZZ -> ___ZZ"),
-        stim.Flow("__Y__ -> __Y__"),
-        stim.Flow("_XZ__ -> _ZX__ xor rec[0]"),
-        stim.Flow("_ZZ__ -> _ZZ__"),
-        stim.Flow("X____ -> X____"),
-        stim.Flow("Z____ -> Z____"),
+        lestim.Flow("1 -> ___YY xor rec[1]"),
+        lestim.Flow("1 -> _YY__ xor rec[0]"),
+        lestim.Flow("____Y -> ____Y"),
+        lestim.Flow("___XZ -> ___ZX xor rec[1]"),
+        lestim.Flow("___ZZ -> ___ZZ"),
+        lestim.Flow("__Y__ -> __Y__"),
+        lestim.Flow("_XZ__ -> _ZX__ xor rec[0]"),
+        lestim.Flow("_ZZ__ -> _ZZ__"),
+        lestim.Flow("X____ -> X____"),
+        lestim.Flow("Z____ -> Z____"),
     ]
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         MPP Y1*Y2 Y3*Y4
     """).flow_generators() == [
-        stim.Flow("1 -> ___YY xor rec[1]"),
-        stim.Flow("1 -> _YY__ xor rec[0]"),
-        stim.Flow("____Y -> ____Y"),
-        stim.Flow("___XZ -> ___ZX xor rec[1]"),
-        stim.Flow("___ZZ -> ___ZZ"),
-        stim.Flow("__Y__ -> __Y__"),
-        stim.Flow("_XZ__ -> _ZX__ xor rec[0]"),
-        stim.Flow("_ZZ__ -> _ZZ__"),
-        stim.Flow("X____ -> X____"),
-        stim.Flow("Z____ -> Z____"),
+        lestim.Flow("1 -> ___YY xor rec[1]"),
+        lestim.Flow("1 -> _YY__ xor rec[0]"),
+        lestim.Flow("____Y -> ____Y"),
+        lestim.Flow("___XZ -> ___ZX xor rec[1]"),
+        lestim.Flow("___ZZ -> ___ZZ"),
+        lestim.Flow("__Y__ -> __Y__"),
+        lestim.Flow("_XZ__ -> _ZX__ xor rec[0]"),
+        lestim.Flow("_ZZ__ -> _ZZ__"),
+        lestim.Flow("X____ -> X____"),
+        lestim.Flow("Z____ -> Z____"),
     ]
 
 
 def test_solve_flow_measurements_multi_target():
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         M 1 2
     """).solve_flow_measurements([
-        stim.Flow("Z1 -> 1"),
+        lestim.Flow("Z1 -> 1"),
     ]) == [[0]]
 
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         MX 1 2
     """).solve_flow_measurements([
-        stim.Flow("X1 -> 1"),
+        lestim.Flow("X1 -> 1"),
     ]) == [[0]]
 
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         MYY 1 2 3 4
     """).solve_flow_measurements([
-        stim.Flow("Y1*Y2 -> 1"),
+        lestim.Flow("Y1*Y2 -> 1"),
     ]) == [[0]]
 
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         MPP Y1*Y2 Y3*Y4
     """).solve_flow_measurements([
-        stim.Flow("Y1*Y2 -> 1"),
+        lestim.Flow("Y1*Y2 -> 1"),
     ]) == [[0]]
 
 
 def test_solve_flow_measurements_fewer_measurements_heuristic():
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         MPP Z0*Z1*Z2*Z3*Z4*Z5*Z6*Z7*Z8
         M 0 1 2 3 4 5 6 7 8
     """).solve_flow_measurements([
-        stim.Flow("1 -> Z0*Z1*Z2*Z3*Z4*Z5*Z6*Z7*Z8"),
+        lestim.Flow("1 -> Z0*Z1*Z2*Z3*Z4*Z5*Z6*Z7*Z8"),
     ]) == [[0]]
 
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         MPP Z0*Z1*Z2*Z3*Z4*Z5*Z6*Z7*Z8
         M 0 1 2 3 4 5 6 7 8
     """).solve_flow_measurements([
-        stim.Flow("Z0*Z1*Z2*Z3*Z4*Z5*Z6*Z7*Z8 -> 1"),
+        lestim.Flow("Z0*Z1*Z2*Z3*Z4*Z5*Z6*Z7*Z8 -> 1"),
     ]) == [[0]]
 
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         M 0 1 2 3 4 5 6 7 8
         MPP Z0*Z1*Z2*Z3*Z4*Z5*Z6*Z7*Z8
     """).solve_flow_measurements([
-        stim.Flow("1 -> Z0*Z1*Z2*Z3*Z4*Z5*Z6*Z7*Z8"),
+        lestim.Flow("1 -> Z0*Z1*Z2*Z3*Z4*Z5*Z6*Z7*Z8"),
     ]) == [[9]]
 
-    assert stim.Circuit("""
+    assert lestim.Circuit("""
         M 0 1 2 3 4 5 6 7 8
         MPP Z0*Z1*Z2*Z3*Z4*Z5*Z6*Z7*Z8
     """).solve_flow_measurements([
-        stim.Flow("Z0*Z1*Z2*Z3*Z4*Z5*Z6*Z7*Z8 -> 1"),
+        lestim.Flow("Z0*Z1*Z2*Z3*Z4*Z5*Z6*Z7*Z8 -> 1"),
     ]) == [[9]]

--- a/src/stim/util_top/circuit_inverse_qec_test.py
+++ b/src/stim/util_top/circuit_inverse_qec_test.py
@@ -1,19 +1,19 @@
 import pytest
-import stim
+import lestim
 
 
 def test_inv_circuit():
-    inv_circuit, inv_flows = stim.Circuit().time_reversed_for_flows([])
-    assert inv_circuit == stim.Circuit()
+    inv_circuit, inv_flows = lestim.Circuit().time_reversed_for_flows([])
+    assert inv_circuit == lestim.Circuit()
     assert inv_flows == []
 
-    inv_circuit, inv_flows = stim.Circuit("""
+    inv_circuit, inv_flows = lestim.Circuit("""
         R 0
         H 0
         MX 0
         DETECTOR rec[-1]
     """).time_reversed_for_flows([])
-    assert inv_circuit == stim.Circuit("""
+    assert inv_circuit == lestim.Circuit("""
         RX 0
         H 0
         M 0
@@ -21,46 +21,46 @@ def test_inv_circuit():
     """)
     assert inv_flows == []
 
-    inv_circuit, inv_flows = stim.Circuit("""
+    inv_circuit, inv_flows = lestim.Circuit("""
         M 0
-    """).time_reversed_for_flows([stim.Flow('Z -> rec[-1]')])
-    assert inv_circuit == stim.Circuit("""
+    """).time_reversed_for_flows([lestim.Flow('Z -> rec[-1]')])
+    assert inv_circuit == lestim.Circuit("""
         R 0
     """)
-    assert inv_flows == [stim.Flow('1 -> Z')]
+    assert inv_flows == [lestim.Flow('1 -> Z')]
     assert inv_circuit.has_all_flows(inv_flows, unsigned=True)
 
-    inv_circuit, inv_flows = stim.Circuit("""
+    inv_circuit, inv_flows = lestim.Circuit("""
         R 0
-    """).time_reversed_for_flows([stim.Flow('1 -> Z')])
-    assert inv_circuit == stim.Circuit("""
+    """).time_reversed_for_flows([lestim.Flow('1 -> Z')])
+    assert inv_circuit == lestim.Circuit("""
         M 0
     """)
-    assert inv_flows == [stim.Flow('Z -> rec[-1]')]
+    assert inv_flows == [lestim.Flow('Z -> rec[-1]')]
 
-    inv_circuit, inv_flows = stim.Circuit("""
+    inv_circuit, inv_flows = lestim.Circuit("""
         M 0
-    """).time_reversed_for_flows([stim.Flow('1 -> Z xor rec[-1]')])
-    assert inv_circuit == stim.Circuit("""
+    """).time_reversed_for_flows([lestim.Flow('1 -> Z xor rec[-1]')])
+    assert inv_circuit == lestim.Circuit("""
         M 0
     """)
-    assert inv_flows == [stim.Flow('Z -> rec[-1]')]
+    assert inv_flows == [lestim.Flow('Z -> rec[-1]')]
 
-    inv_circuit, inv_flows = stim.Circuit("""
+    inv_circuit, inv_flows = lestim.Circuit("""
         M 0
     """).time_reversed_for_flows(
-        flows=[stim.Flow('Z -> rec[-1]')],
+        flows=[lestim.Flow('Z -> rec[-1]')],
         dont_turn_measurements_into_resets=True,
     )
-    assert inv_circuit == stim.Circuit("""
+    assert inv_circuit == lestim.Circuit("""
         M 0
     """)
-    assert inv_flows == [stim.Flow('1 -> Z xor rec[-1]')]
+    assert inv_flows == [lestim.Flow('1 -> Z xor rec[-1]')]
 
-    inv_circuit, inv_flows = stim.Circuit("""
+    inv_circuit, inv_flows = lestim.Circuit("""
         MR(0.125) 0
     """).time_reversed_for_flows([])
-    assert inv_circuit == stim.Circuit("""
+    assert inv_circuit == lestim.Circuit("""
         MR 0
         X_ERROR(0.125) 0
     """)
@@ -68,7 +68,7 @@ def test_inv_circuit():
 
 
 def test_inv_circuit_surface_code():
-    circuit = stim.Circuit.generated(
+    circuit = lestim.Circuit.generated(
         "surface_code:rotated_memory_x",
         distance=3,
         rounds=2,
@@ -81,7 +81,7 @@ def test_inv_circuit_surface_code():
 
     # Check observable is time reversed.
     num_ticks = circuit.num_ticks
-    l0 = stim.target_logical_observable_id(0)
+    l0 = lestim.target_logical_observable_id(0)
     assert inv_circuit.num_ticks == num_ticks
     assert {num_ticks - t - 1: v for t, v in det_regions[l0].items()} == inv_det_regions[l0]
 
@@ -98,28 +98,28 @@ def test_inv_circuit_surface_code():
 
 def test_more_flow_qubits_than_circuit_qubits():
     flows = [
-        stim.Flow("X300 -> X300"),
-        stim.Flow("X2*Z301 -> Z2*Z301"),
+        lestim.Flow("X300 -> X300"),
+        lestim.Flow("X2*Z301 -> Z2*Z301"),
     ]
-    circuit = stim.Circuit("H 2")
+    circuit = lestim.Circuit("H 2")
     assert circuit.has_flow(flows[0])
     assert circuit.has_flow(flows[1])
     assert circuit.has_all_flows(flows)
     new_circuit, new_flows = circuit.time_reversed_for_flows(flows=flows)
     assert new_circuit == circuit
     assert new_flows == [
-        stim.Flow("X300 -> X300"),
-        stim.Flow("Z2*Z301 -> X2*Z301"),
+        lestim.Flow("X300 -> X300"),
+        lestim.Flow("Z2*Z301 -> X2*Z301"),
     ]
 
 
 def test_measurement_ordering():
-    circuit = stim.Circuit("""
+    circuit = lestim.Circuit("""
         M 0 1
     """)
     flows = [
-        stim.Flow("I -> Z0 xor rec[-2]"),
-        stim.Flow("I -> Z1 xor rec[-1]"),
+        lestim.Flow("I -> Z0 xor rec[-2]"),
+        lestim.Flow("I -> Z1 xor rec[-1]"),
     ]
     assert circuit.has_all_flows(flows, unsigned=True)
     new_circuit, new_flows = circuit.time_reversed_for_flows(flows)
@@ -127,12 +127,12 @@ def test_measurement_ordering():
 
 
 def test_measurement_ordering_2():
-    circuit = stim.Circuit("""
+    circuit = lestim.Circuit("""
         MZZ 0 1 2 3
     """)
     flows = [
-        stim.Flow("I -> Z0*Z1 xor rec[-2]"),
-        stim.Flow("I -> Z2*Z3 xor rec[-1]"),
+        lestim.Flow("I -> Z0*Z1 xor rec[-2]"),
+        lestim.Flow("I -> Z2*Z3 xor rec[-1]"),
     ]
     assert circuit.has_all_flows(flows, unsigned=True)
     new_circuit, new_flows = circuit.time_reversed_for_flows(flows)
@@ -140,14 +140,14 @@ def test_measurement_ordering_2():
 
 
 def test_measurement_ordering_3():
-    circuit = stim.Circuit("""
+    circuit = lestim.Circuit("""
         MR 0 1
     """)
     flows = [
-        stim.Flow("Z0 -> rec[-2]"),
-        stim.Flow("Z1 -> rec[-1]"),
-        stim.Flow("I -> Z0"),
-        stim.Flow("I -> Z1"),
+        lestim.Flow("Z0 -> rec[-2]"),
+        lestim.Flow("Z1 -> rec[-1]"),
+        lestim.Flow("I -> Z0"),
+        lestim.Flow("I -> Z1"),
     ]
     assert circuit.has_all_flows(flows, unsigned=True)
     new_circuit, new_flows = circuit.time_reversed_for_flows(flows)
@@ -155,25 +155,25 @@ def test_measurement_ordering_3():
 
 
 def test_feedback():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         R 1
         M 1
         CX rec[-1] 0
     """)
     with pytest.raises(ValueError):
-        c.time_reversed_for_flows([stim.Flow("Z0 -> Z0")])
+        c.time_reversed_for_flows([lestim.Flow("Z0 -> Z0")])
         # TODO: once feedback is supported verify the inv flow is correct
 
 
 def test_obs_include_paulis():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         RX 0
         OBSERVABLE_INCLUDE[test1](2) X0
         OBSERVABLE_INCLUDE[test2](3) Y1
         MY 1
         OBSERVABLE_INCLUDE(3) rec[-1]
     """)
-    assert c.time_reversed_for_flows([]) == (stim.Circuit("""
+    assert c.time_reversed_for_flows([]) == (lestim.Circuit("""
         RY 1
         OBSERVABLE_INCLUDE[test2](3) Y1
         OBSERVABLE_INCLUDE[test1](2) X0

--- a/src/stim/util_top/circuit_to_detecting_regions_test.py
+++ b/src/stim/util_top/circuit_to_detecting_regions_test.py
@@ -1,9 +1,9 @@
 import pytest
-import stim
+import lestim
 
 
 def test_detecting_regions_fails_on_anticommutations_at_start_of_circuit():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         TICK
         R 0
         TICK
@@ -14,7 +14,7 @@ def test_detecting_regions_fails_on_anticommutations_at_start_of_circuit():
     with pytest.raises(ValueError, match="anticommutation"):
         c.detecting_regions()
 
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         R 0
         TICK
         MX 0
@@ -24,7 +24,7 @@ def test_detecting_regions_fails_on_anticommutations_at_start_of_circuit():
     with pytest.raises(ValueError, match="anticommutation"):
         c.detecting_regions()
 
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         MX 0
         DETECTOR rec[-1]
     """)

--- a/src/stim/util_top/export_crumble_url_pybind_test.py
+++ b/src/stim/util_top/export_crumble_url_pybind_test.py
@@ -1,8 +1,8 @@
-import stim
+import lestim
 
 
 def test_to_crumble_url_simple():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         QUBIT_COORDS(2, 1) 0
         QUBIT_COORDS(2, 2) 1
         H 0
@@ -18,12 +18,12 @@ def test_to_crumble_url_simple():
 
 
 def test_to_crumble_url_complex():
-    c = stim.Circuit.generated('surface_code:rotated_memory_x', distance=3, rounds=2, after_clifford_depolarization=0.001)
+    c = lestim.Circuit.generated('surface_code:rotated_memory_x', distance=3, rounds=2, after_clifford_depolarization=0.001)
     assert 'DEPOLARIZE1' in c.to_crumble_url()
 
 
 def test_to_crumble_url_mark_error():
-    c = stim.Circuit.generated('surface_code:rotated_memory_x', distance=3, rounds=2, after_clifford_depolarization=0.001, before_round_data_depolarization=0.001)
+    c = lestim.Circuit.generated('surface_code:rotated_memory_x', distance=3, rounds=2, after_clifford_depolarization=0.001, before_round_data_depolarization=0.001)
     err = c.shortest_graphlike_error(canonicalize_circuit_errors=True)
     url = c.to_crumble_url(skip_detectors=True, mark={1: err})
     assert 'MARKZ' in url

--- a/src/stim/util_top/export_quirk_url_pybind_test.py
+++ b/src/stim/util_top/export_quirk_url_pybind_test.py
@@ -1,8 +1,8 @@
-import stim
+import lestim
 
 
 def test_to_quirk_url_simple():
-    c = stim.Circuit("""
+    c = lestim.Circuit("""
         QUBIT_COORDS(2, 1) 0
         QUBIT_COORDS(2, 2) 1
         H 0
@@ -18,5 +18,5 @@ def test_to_quirk_url_simple():
 
 
 def test_to_quirk_url_complex():
-    c = stim.Circuit.generated('surface_code:rotated_memory_x', distance=2, rounds=2, after_clifford_depolarization=0.001)
+    c = lestim.Circuit.generated('surface_code:rotated_memory_x', distance=2, rounds=2, after_clifford_depolarization=0.001)
     assert '"H"' in c.to_quirk_url()


### PR DESCRIPTION
FIx deltakit-stim vs. stim incompatibility. In detail, this PR addresses:

* Test deltakit-stim python bindings with same build method as the published package.

* Don't use bazel in python binding test CI.

* Add deltakit-stim + stim compatibility test.

* Make DemInstruction and CliffordString module_local.