### PR TITLE
release: Update cibuildwheel version to support releases for 3.14.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.4.0
+        uses: pypa/cibuildwheel@v4.1.0
 
       - uses: actions/upload-artifact@v7
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "deltakit-stim"
 version = "0.2.1"
 description = "A Stim extension package to account for non-computational errors."
 readme = "README.md"
-requires-python = ">=3.10,<=3.14"
+requires-python = ">=3.10,<3.15"
 license = { text = "Apache-2.0" }
 # setup.py complains when building sdists
 # See issue https://github.com/pypa/packaging-problems/issues/870
@@ -27,6 +27,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
   "Topic :: Scientific/Engineering",
   "Topic :: Scientific/Engineering :: Quantum Computing",


### PR DESCRIPTION
Update cibuildwheel action to support release for Python 3.14.