### PR TITLE
fix: Update env variable for min target on MacOS.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,7 +210,7 @@ CC=/opt/rh/gcc-toolset-11/root/usr/bin/gcc
 [tool.cibuildwheel.macos]
 archs = "arm64"
 environment = """\
-MACOSX_DEPLOYMENT_TARGET=15.0 \
+MACOSX_DEPLOYMENT_TARGET=16.0 \
 LDFLAGS="-L/opt/homebrew/opt/llvm@16/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm@16/lib/c++" \
 PATH="/usr/local/opt/llvm@16/bin:$PATH" \
 CPPFLAGS="-I/opt/homebrew/opt/llvm@16/include"


### PR DESCRIPTION
Update minimum target for MacOS build following recommendations in [this workflow](https://github.com/Deltakit/deltakit-stim/actions/runs/29243132573/job/86793658496). 