### PR TITLE
fix: fix cibuildwheel for macos release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,16 +20,16 @@ jobs:
           - {os: ubuntu-latest, dist: cp312-manylinux_x86_64}
           - {os: ubuntu-latest, dist: cp313-manylinux_x86_64}
           - {os: ubuntu-latest, dist: cp314-manylinux_x86_64}
-          - {os: macos-latest, dist: cp310-macosx_x86_64, arch: x86_64}
-          - {os: macos-latest, dist: cp311-macosx_x86_64, arch: x86_64}
-          - {os: macos-latest, dist: cp312-macosx_x86_64, arch: x86_64}
-          - {os: macos-latest, dist: cp313-macosx_x86_64, arch: x86_64}
-          - {os: macos-latest, dist: cp314-macosx_x86_64, arch: x86_64}
-          - {os: macos-latest, dist: cp310-macosx_arm64, arch: arm64}
-          - {os: macos-latest, dist: cp311-macosx_arm64, arch: arm64}
-          - {os: macos-latest, dist: cp312-macosx_arm64, arch: arm64}
-          - {os: macos-latest, dist: cp313-macosx_arm64, arch: arm64}
-          - {os: macos-latest, dist: cp314-macosx_arm64, arch: arm64}
+          - {os: macos-26-intel, dist: cp310-macosx_x86_64, arch: x86_64}
+          - {os: macos-26-intel, dist: cp311-macosx_x86_64, arch: x86_64}
+          - {os: macos-26-intel, dist: cp312-macosx_x86_64, arch: x86_64}
+          - {os: macos-26-intel, dist: cp313-macosx_x86_64, arch: x86_64}
+          - {os: macos-26-intel, dist: cp314-macosx_x86_64, arch: x86_64}
+          - {os: macos-26, dist: cp310-macosx_arm64, arch: arm64}
+          - {os: macos-26, dist: cp311-macosx_arm64, arch: arm64}
+          - {os: macos-26, dist: cp312-macosx_arm64, arch: arm64}
+          - {os: macos-26, dist: cp313-macosx_arm64, arch: arm64}
+          - {os: macos-26, dist: cp314-macosx_arm64, arch: arm64}
     runs-on: ${{ matrix.os_dist.os }}
     env:
       CIBW_BUILD: "${{ matrix.os_dist.dist }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,7 +210,7 @@ CC=/opt/rh/gcc-toolset-11/root/usr/bin/gcc
 [tool.cibuildwheel.macos]
 archs = "arm64"
 environment = """\
-MACOSX_DEPLOYMENT_TARGET=15.0 \
+MACOSX_DEPLOYMENT_TARGET=16.0 \
 LDFLAGS="-L/opt/homebrew/opt/llvm@16/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm@16/lib/c++" \
 PATH="/usr/local/opt/llvm@16/bin:$PATH" \
 CPPFLAGS="-I/opt/homebrew/opt/llvm@16/include"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,7 +210,7 @@ CC=/opt/rh/gcc-toolset-11/root/usr/bin/gcc
 [tool.cibuildwheel.macos]
 archs = "arm64"
 environment = """\
-MACOSX_DEPLOYMENT_TARGET=16.0 \
+MACOSX_DEPLOYMENT_TARGET=26.0 \
 LDFLAGS="-L/opt/homebrew/opt/llvm@16/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm@16/lib/c++" \
 PATH="/usr/local/opt/llvm@16/bin:$PATH" \
 CPPFLAGS="-I/opt/homebrew/opt/llvm@16/include"


### PR DESCRIPTION
Bump target release according to recommendations in [this workflow](https://github.com/Deltakit/deltakit-stim/actions/runs/29253990954/job/86829205409).