### PR TITLE
fix: add fallback to polyfill when SIMD extensions are missing

### DIFF
--- a/glue/python/src/deltakit_stim/__init__.py
+++ b/glue/python/src/deltakit_stim/__init__.py
@@ -13,10 +13,14 @@ _tmp = _tmp._UNSTABLE_detect_march()
 # if _tmp == 'avx2':
 #     from deltakit_stim._stim_avx2 import *
 #     from deltakit_stim._stim_avx2 import _UNSTABLE_raw_format_data, __version__
-if _tmp == 'avx2' or _tmp == 'sse2':
-    from deltakit_stim._stim_sse2 import *
-    from deltakit_stim._stim_sse2 import _UNSTABLE_raw_format_data, __version__
-else:
+try:
+    if _tmp == 'avx2' or _tmp == 'sse2':
+        from deltakit_stim._stim_sse2 import *
+        from deltakit_stim._stim_sse2 import _UNSTABLE_raw_format_data, __version__
+    else:
+        from deltakit_stim._stim_polyfill import *
+        from deltakit_stim._stim_polyfill import _UNSTABLE_raw_format_data, __version__
+except (ImportError, ModuleNotFoundError):
     from deltakit_stim._stim_polyfill import *
     from deltakit_stim._stim_polyfill import _UNSTABLE_raw_format_data, __version__
 del _tmp


### PR DESCRIPTION
### Problem
On macOS (specifically x86_64 / Rosetta environments), CPU architecture detection in `deltakit_stim` returns `sse2` (or `avx2`), causing `deltakit_stim/__init__.py` to attempt:

```python
if _tmp == 'avx2' or _tmp == 'sse2':
    from deltakit_stim._stim_sse2 import *
```

However, in the pre-built macOS wheel distribution on PyPI (`deltakit_stim-0.2.0-cp311-cp311-macosx_15_0_x86_64.whl`), `_stim_sse2.so` was omitted during the build, shipping only `_stim_polyfill.so`.

Because there is no exception handler around the import, installing and running `deltakit` on macOS raises an unhandled crash:

```
ModuleNotFoundError: No module named 'deltakit_stim._stim_sse2'
```

### Solution
- Wraps the dynamic architecture import in a `try...except (ImportError, ModuleNotFoundError)` block.
- If `_stim_sse2` is present, it will load for fast SIMD execution.
- If `_stim_sse2` is missing from the installed package, it gracefully falls back to _stim_polyfill instead of crashing.

### Verification
Tested on macOS 15 (Sequoia, Python 3.11.4):
- Confirmed `import deltakit` and `import deltakit_stim` now load cleanly without errors.
- Verified basic quantum circuit creation and sampling runs with 100% accuracy.